### PR TITLE
Feat: 경험 분해 세부정보 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ build/
 !**/src/test/**/build/
 
 src/main/resources/application.yml
+src/main/resources/application-dev.yml
+src/main/resources/application-prod.yml
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/codez4/meetfolio/domain/board/EmploymentBoard.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/EmploymentBoard.java
@@ -1,6 +1,6 @@
 package com.codez4.meetfolio.domain.board;
 
-import com.codez4.meetfolio.domain.enums.JobKeywordEnum;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @DiscriminatorValue("EMPLOYMENT")
 public class EmploymentBoard extends Board{
 
-    @Column(name = "job_category",nullable = true)
+    @Column(name = "job_category")
     @Enumerated(value = EnumType.STRING)
-    private JobKeywordEnum jobKeywordEnum;
+    private JobKeyword jobKeyword;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -1,11 +1,24 @@
 package com.codez4.meetfolio.domain.coverLetter;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.ShareType;
-import com.codez4.meetfolio.domain.jobKeyword.JobKeyword;
 import com.codez4.meetfolio.domain.member.Member;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -16,11 +29,11 @@ public class CoverLetter extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "cover_letter_id",nullable = false)
+    @Column(name = "cover_letter_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id",nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Column(nullable = false)
@@ -33,13 +46,13 @@ public class CoverLetter extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ShareType shareType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = true)
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private JobKeyword jobKeyword;
 
-    @Column(name = "keyword_1",nullable = true)
+    @Column(name = "keyword_1")
     private String keyword1;
 
-    @Column(name = "keyword_2",nullable = true)
+    @Column(name = "keyword_2")
     private String keyword2;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/dataset/Dataset.java
+++ b/src/main/java/com/codez4/meetfolio/domain/dataset/Dataset.java
@@ -1,7 +1,7 @@
 package com.codez4.meetfolio.domain.dataset;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
-import com.codez4.meetfolio.domain.enums.JobKeywordEnum;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,7 +18,7 @@ public class Dataset extends BaseTimeEntity {
 
     @Column(name = "job")
     @Enumerated(value = EnumType.STRING)
-    private JobKeywordEnum jobKeywordEnum;
+    private JobKeyword jobKeyword;
 
     @Column(nullable = false)
     private String url;

--- a/src/main/java/com/codez4/meetfolio/domain/enums/Authority.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/Authority.java
@@ -1,14 +1,7 @@
 package com.codez4.meetfolio.domain.enums;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum Authority {
 
-    USER,
-    ADMIN
-    ;
+    MEMBER, ADMIN;
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/enums/JobKeyword.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/JobKeyword.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum JobKeywordEnum {
+public enum JobKeyword {
 
     BACKEND("백엔드"),
     WEB("웹개발"),

--- a/src/main/java/com/codez4/meetfolio/domain/experience/Experience.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/Experience.java
@@ -1,12 +1,24 @@
 package com.codez4.meetfolio.domain.experience;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
-import com.codez4.meetfolio.domain.jobKeyword.JobKeyword;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.member.Member;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -14,27 +26,23 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 public class Experience extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "experience_id",nullable = false)
+    @Column(name = "experience_id", nullable = false)
     private Long id;
 
     @Column(nullable = false)
     private String title;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id",nullable = false)
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_keyword_id", nullable = false)
-    private JobKeyword jobKeyword;
 
     @Column(nullable = false)
     private LocalDate startDate;
 
     @Column(nullable = false)
     private LocalDate endDate;
+
+    @Column(nullable = false)
+    private String experienceType;
 
     @Column(nullable = false)
     private String stack;
@@ -51,4 +59,11 @@ public class Experience extends BaseTimeEntity {
     @Column(nullable = false)
     private String advance;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private JobKeyword jobKeyword;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -1,0 +1,42 @@
+package com.codez4.meetfolio.domain.experience.controller;
+
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceResult;
+
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceResult;
+import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
+import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "경험 분해 API")
+@RestController
+@RequestMapping("/api/experiences")
+@RequiredArgsConstructor
+public class ExperienceController {
+
+    private final ExperienceQueryService experienceQueryService;
+    private final MemberQueryService memberQueryService;
+
+    @Operation(summary = "경험 분해 상세정보 조회", description = "특정 경험 분해 정보를 조회합니다.")
+    @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @GetMapping("/{experienceId}")
+    public ApiResponse<ExperienceResult> getExperience(
+        @PathVariable(name = "experienceId") Long experienceId) {
+
+        // TODO: 추후 로그인 사용자로 수정
+        MemberInfo memberInfo = memberQueryService.getMemberInfo(1L);
+        ExperienceInfo experienceInfo = experienceQueryService.getExperience(experienceId);
+
+        return ApiResponse.onSuccess(toExperienceResult(memberInfo, experienceInfo));
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
@@ -1,0 +1,86 @@
+package com.codez4.meetfolio.domain.experience.dto;
+
+import com.codez4.meetfolio.domain.experience.Experience;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ExperienceResponse {
+
+    @Schema(description = "사용자 정보 및 경험 분해 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class ExperienceResult {
+
+        private MemberInfo memberInfo;
+        private ExperienceInfo experienceInfo;
+    }
+
+    public static ExperienceResult toExperienceResult(MemberInfo memberInfo,
+        ExperienceInfo experienceInfo) {
+        return ExperienceResult.builder()
+            .memberInfo(memberInfo)
+            .experienceInfo(experienceInfo)
+            .build();
+    }
+
+    @Schema(description = "경험 분해 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class ExperienceInfo {
+
+        @Schema(description = "경험 제목")
+        private String title;
+
+        @Schema(description = "경험 시작 기간 ")
+        private LocalDate startDate;
+
+        @Schema(description = "경험 종료 기간")
+        private LocalDate endDate;
+
+        @Schema(description = "경험 카테고리")
+        private String experienceType;
+
+        @Schema(description = "경험 업무 내용")
+        private String task;
+
+        @Schema(description = "경험 동기 & 이유")
+        private String motivation;
+
+        @Schema(description = "맡았던 직무")
+        private String jobKeyword;
+
+        @Schema(description = "사용한 기술 스택", example = "spring/mysql")
+        private String stack;
+
+        @Schema(description = "경험 세부 내용")
+        private String detail;
+
+        @Schema(description = "결과 및 성과")
+        private String advance;
+    }
+
+    public static ExperienceInfo toExperienceInfo(Experience experience) {
+
+        return ExperienceInfo.builder()
+            .title(experience.getTitle())
+            .startDate(experience.getStartDate())
+            .endDate(experience.getEndDate())
+            .experienceType(experience.getExperienceType())
+            .task(experience.getTask())
+            .motivation(experience.getMotivation())
+            .jobKeyword(experience.getJobKeyword().getDescription())
+            .stack(experience.getStack())
+            .detail(experience.getDetail())
+            .advance(experience.getAdvance())
+            .build();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
@@ -1,0 +1,8 @@
+package com.codez4.meetfolio.domain.experience.repository;
+
+import com.codez4.meetfolio.domain.experience.Experience;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
@@ -1,0 +1,29 @@
+package com.codez4.meetfolio.domain.experience.service;
+
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceInfo;
+
+import com.codez4.meetfolio.domain.experience.Experience;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
+import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExperienceQueryService {
+
+    private final ExperienceRepository experienceRepository;
+
+    public ExperienceInfo getExperience(Long experienceId) {
+
+        // 경험 분해
+        Experience experience = experienceRepository.findById(experienceId).orElseThrow(
+            () -> new ApiException(ErrorStatus._EXPERIENCE_NOT_FOUND));
+
+        return toExperienceInfo(experience);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/Member.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/Member.java
@@ -3,15 +3,24 @@ package com.codez4.meetfolio.domain.member;
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.enums.Authority;
 import com.codez4.meetfolio.domain.enums.Grade;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.Major;
 import com.codez4.meetfolio.domain.enums.Status;
-import com.codez4.meetfolio.domain.jobKeyword.JobKeyword;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
-
-import java.time.LocalDateTime;
 
 @DynamicInsert
 @Getter
@@ -46,19 +55,19 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @Column(nullable = true)
-    private String image;
+    @Column
+    private String profile;
 
     @Column(nullable = false)
     @ColumnDefault("'MEMBER'")
     @Enumerated(EnumType.STRING)
     private Authority authority ;
 
-    @Column(nullable = true)
+    @Column
     private LocalDateTime inactiveDate;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_keyword_id",nullable = false)
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private JobKeyword jobKeyword;
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -1,0 +1,35 @@
+package com.codez4.meetfolio.domain.member.dto;
+
+import com.codez4.meetfolio.domain.member.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberResponse {
+
+    @Schema(description = "사용자 정보 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MemberInfo {
+
+        @Schema(description = "사용자 이름")
+        private String memberName;
+        @Schema(description = "사용자 프로필")
+        private String profile;
+        @Schema(description = "사용자 학과")
+        private String major;
+    }
+
+    public static MemberInfo toMemberInfo(Member member) {
+
+        return MemberInfo.builder()
+            .memberName(member.getEmail())
+            .profile(member.getProfile())
+            .major(member.getMajor().name())
+            .build();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.codez4.meetfolio.domain.member.repository;
+
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -1,0 +1,31 @@
+package com.codez4.meetfolio.domain.member.service;
+
+import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
+
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
+import com.codez4.meetfolio.domain.member.repository.MemberRepository;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id).orElseThrow(
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+        );
+    }
+
+    public MemberInfo getMemberInfo(Long memberId) {
+        return toMemberInfo(findById(memberId));
+    }
+
+}

--- a/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
@@ -14,9 +14,19 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // ================================================================================================================= //
+
+    // 사용자 관련
+    _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "존재하지 않는 사용자 정보입니다."),
+
+
+    // ================================================================================================================= //
+
+    // 경험 분해 관련
+    _EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXPERIENCE4001", "존재하지 않는 경험 분해 데이터입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 요약

- 경험 분해 세부정보 조회 API 구현
- Controller, ResponseDTO Swagger 적용

## 상세 내용

- 로그인 사용자 정보를 임의의로 생성하여 진행, 추후에 변경
- dto인 경우에 MemberInfo, ExperienceInfo로 각 도메인 별로 정보를 나누어 담아서 전달, 두 DTO를 담는 변수명은 ExperiecneResult를 사용, 단일 값은 Result로 하기

<img width="621" alt="image" src="https://github.com/Meetfolio-Project-CodeZ-Team/Backend/assets/103489352/97adbb59-6d7b-429e-9f4f-b906ca1f8e2c">

## 질문 및 이외 사항

- Keyword.class 경우에 Member, Experience와 일대다로 매핑되어 있어 조회하거나 생성할 때 DB 쿼리가 1번 더 필요한 불편함이 있었음 
> Keyword인 경우 백엔드, 웹개발, 앱개발, 디자인, AI, PM 6개로 고정해서 사용하기에 그냥 ENUM 타입을 통해 사용하는게 더 효율적일거 같은데 어떤지 얘기해보면 좋을 것 같습니다.

## 이슈 번호

- close #9 
