### PR TITLE
Feat : 경험 카드 목록, 세부 정보, 추천 경험 카드 조회 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -1,8 +1,11 @@
 package com.codez4.meetfolio.domain.experience.controller;
 
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardResult;
 import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceResult;
 
 import com.codez4.meetfolio.domain.experience.dto.ExperienceRequest;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardResult;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceProc;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceResult;
@@ -24,11 +27,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "경험 분해 API")
 @RestController
-@RequestMapping("/api/experiences")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ExperienceController {
 
@@ -38,7 +43,7 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 상세정보 조회", description = "특정 경험 분해 정보를 조회합니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @GetMapping("/{experienceId}")
+    @GetMapping("/experiences/{experienceId}")
     public ApiResponse<ExperienceResult> getExperience(
         @PathVariable(name = "experienceId") Long experienceId) {
 
@@ -50,7 +55,7 @@ public class ExperienceController {
     }
 
     @Operation(summary = "경험 분해 작성", description = "경험 분해 작성 요청을 POST로 보냅니다.")
-    @PostMapping
+    @PostMapping("/experiences")
     public ApiResponse<ExperienceProc> post(@RequestBody ExperienceRequest post) {
 
         // TODO: 추후 로그인 사용자로 수정 - 1L
@@ -61,7 +66,7 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 수정", description = "경험 분해 수정 요청을 PATCH로 보냅니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @PatchMapping("{experienceId}")
+    @PatchMapping("/experiences{experienceId}")
     public ApiResponse<ExperienceProc> patch(@RequestBody ExperienceRequest patch,
         @PathVariable(name = "experienceId") Long experienceId) {
 
@@ -70,10 +75,27 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 삭제", description = "경험 분해 삭제 요청을 DELETE로 보냅니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @DeleteMapping("{experienceId}")
-    public ApiResponse<ExperienceProc> delete(@PathVariable(name = "experienceId") Long experienceId) {
+    @DeleteMapping("/experiences{experienceId}")
+    public ApiResponse<ExperienceProc> delete(
+        @PathVariable(name = "experienceId") Long experienceId) {
 
         return ApiResponse.onSuccess(experienceCommandService.delete(experienceId));
+    }
+
+    @Operation(summary = "경험 카드 목록 조회", description = "경험 카드 목록(Paging) 조회 GET으로 보냅니다.")
+    @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
+    @GetMapping("/experience-cards")
+    public ApiResponse<ExperienceCardResult> getExperienceCards(
+        @RequestParam(value = "page", defaultValue = "0") int page) {
+
+        // TODO: 추후 로그인 사용자로 변경 - 1L
+        Member member = memberQueryService.findById(1L);
+        MemberInfo memberInfo = memberQueryService.getMemberInfo(1L);
+
+        ExperienceCardInfo experienceCardInfo = experienceQueryService.getExperienceCardInfo(member,
+            page);
+
+        return ApiResponse.onSuccess(toExperienceCardResult(memberInfo, experienceCardInfo));
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -2,16 +2,20 @@ package com.codez4.meetfolio.domain.experience.controller;
 
 import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardResult;
 import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceResult;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toRecommendCard;
 
 import com.codez4.meetfolio.domain.experience.dto.ExperienceRequest;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardItem;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardResult;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceProc;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceResult;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.RecommendCard;
 import com.codez4.meetfolio.domain.experience.service.ExperienceCommandService;
 import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.response.ApiResponse;
@@ -19,6 +23,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +45,19 @@ public class ExperienceController {
     private final ExperienceQueryService experienceQueryService;
     private final ExperienceCommandService experienceCommandService;
     private final MemberQueryService memberQueryService;
+
+    @Operation(summary = "랜딩 페이지 - 추천 카드 12개 조회", description = "비로그인 사용자는 랜덤 12개, 로그인 사용자는 희망 직무에 따라 12개 추천")
+    @GetMapping
+    public ApiResponse<RecommendCard> recommendCard() {
+
+        // TODO: 추후 로그인 사용자로 변경
+        Member member = memberQueryService.findById(1L);
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
+        List<ExperienceCardItem> recommendCardInfo = experienceQueryService.getRecommendCard(
+            member);
+
+        return ApiResponse.onSuccess(toRecommendCard(memberInfo, recommendCardInfo));
+    }
 
     @Operation(summary = "경험 분해 상세정보 조회", description = "특정 경험 분해 정보를 조회합니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
@@ -207,4 +207,30 @@ public class ExperienceResponse {
             .stack(experience.getStack())
             .build();
     }
+
+    @Schema(description = "랜딩페이지 추천 경험 카드 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class RecommendCard {
+
+        private MemberInfo memberInfo;
+        private List<ExperienceCardItem> recommendCardInfo;
+    }
+
+    public static RecommendCard toRecommendCard(MemberInfo memberInfo,
+        List<ExperienceCardItem> experienceCardItems) {
+
+        return RecommendCard.builder()
+            .memberInfo(memberInfo)
+            .recommendCardInfo(experienceCardItems)
+            .build();
+    }
+
+    public static List<ExperienceCardItem> toExperienceCardItems(List<Experience> experiences) {
+        return experiences.stream()
+            .map(ExperienceResponse::toExperienceCardItem)
+            .toList();
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
@@ -5,10 +5,12 @@ import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 public class ExperienceResponse {
 
@@ -41,7 +43,7 @@ public class ExperienceResponse {
         @Schema(description = "경험 제목")
         private String title;
 
-        @Schema(description = "경험 시작 기간 ")
+        @Schema(description = "경험 시작 기간")
         private LocalDate startDate;
 
         @Schema(description = "경험 종료 기간")
@@ -103,6 +105,106 @@ public class ExperienceResponse {
         return ExperienceProc.builder()
             .experienceId(experienceId)
             .createdAt(LocalDateTime.now())
+            .build();
+    }
+
+    @Schema(description = "나의 경험 카드 목록 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class ExperienceCardResult {
+
+        private MemberInfo memberInfo;
+        private ExperienceCardInfo experienceCardInfo;
+    }
+
+    public static ExperienceCardResult toExperienceCardResult(MemberInfo memberInfo,
+        ExperienceCardInfo experienceCardInfo) {
+
+        return ExperienceCardResult.builder()
+            .memberInfo(memberInfo)
+            .experienceCardInfo(experienceCardInfo)
+            .build();
+    }
+
+    @Schema(description = "경험 카드 목록 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class ExperienceCardInfo {
+
+        @Schema(description = "경험 카드 목록")
+        private List<ExperienceCardItem> experienceCardItems;
+
+        @Schema(description = "페이징된 리스트의 항목 개수")
+        private Integer listSize;
+
+        @Schema(description = "총 페이징 수 ")
+        private Integer totalPage;
+
+        @Schema(description = "전체 데이터의 개수")
+        private Long totalElements;
+
+        @Schema(description = "첫 페이지의 여부")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지의 여부")
+        private Boolean isLast;
+    }
+
+    public static ExperienceCardInfo toExperienceCardInfo(Page<Experience> experiences) {
+
+        List<ExperienceCardItem> experienceCardItems = experiences.stream()
+            .map(ExperienceResponse::toExperienceCardItem)
+            .toList();
+
+        return ExperienceCardInfo.builder()
+            .experienceCardItems(experienceCardItems)
+            .listSize(experienceCardItems.size())
+            .totalPage(experiences.getTotalPages())
+            .totalElements(experiences.getTotalElements())
+            .isFirst(experiences.isFirst())
+            .isLast(experiences.isLast())
+            .build();
+    }
+
+    @Schema(description = "경험 카드 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class ExperienceCardItem {
+
+        @Schema(description = "경험 제목")
+        private String title;
+
+        @Schema(description = "경험 시작 기간")
+        private String startDate;
+
+        @Schema(description = "경험 종료 기간")
+        private String endDate;
+
+        @Schema(description = "경험 카테고리")
+        private String experienceType;
+
+        @Schema(description = "맡았던 직무")
+        private String jobKeyword;
+
+        @Schema(description = "사용한 기술 스택")
+        private String stack;
+    }
+
+    public static ExperienceCardItem toExperienceCardItem(Experience experience) {
+
+        return ExperienceCardItem.builder()
+            .title(experience.getTitle())
+            .startDate(experience.getStartDate().toString())
+            .endDate(experience.getEndDate().toString())
+            .experienceType(experience.getExperienceType())
+            .jobKeyword(experience.getJobKeyword().getDescription())
+            .stack(experience.getStack())
             .build();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
@@ -1,7 +1,9 @@
 package com.codez4.meetfolio.domain.experience.repository;
 
+import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.member.Member;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +11,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
 
     Page<Experience> findAllByMember(Member member, Pageable pageable);
+
+    List<Experience> findTop12ByJobKeywordOrderByIdDesc(JobKeyword jobKeyword);
+
+    List<Experience> findTop12ByOrderByIdDesc();
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
@@ -1,8 +1,13 @@
 package com.codez4.meetfolio.domain.experience.repository;
 
 import com.codez4.meetfolio.domain.experience.Experience;
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+
+    Page<Experience> findAllByMember(Member member, Pageable pageable);
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
@@ -4,12 +4,15 @@ import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toEx
 import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceInfo;
 
 import com.codez4.meetfolio.domain.experience.Experience;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardItem;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
 import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -39,6 +42,18 @@ public class ExperienceQueryService {
         PageRequest pageRequest = PageRequest.of(page, 6, Sort.by("createdAt").descending());
 
         return toExperienceCardInfo(experienceRepository.findAllByMember(member, pageRequest));
+    }
+
+    public List<ExperienceCardItem> getRecommendCard(Member member) {
+
+        List<Experience> experiences;
+        if (member == null) {
+            experiences = experienceRepository.findTop12ByOrderByIdDesc();
+        } else {
+            experiences = experienceRepository.findTop12ByJobKeywordOrderByIdDesc(
+                member.getJobKeyword());
+        }
+        return ExperienceResponse.toExperienceCardItems(experiences);
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
@@ -1,13 +1,18 @@
 package com.codez4.meetfolio.domain.experience.service;
 
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardInfo;
 import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceInfo;
 
 import com.codez4.meetfolio.domain.experience.Experience;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
 import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
+import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,4 +33,12 @@ public class ExperienceQueryService {
             () -> new ApiException(ErrorStatus._EXPERIENCE_NOT_FOUND)
         );
     }
+
+    public ExperienceCardInfo getExperienceCardInfo(Member member, int page) {
+
+        PageRequest pageRequest = PageRequest.of(page, 6, Sort.by("createdAt").descending());
+
+        return toExperienceCardInfo(experienceRepository.findAllByMember(member, pageRequest));
+    }
+
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -26,10 +26,11 @@ public class MemberResponse {
 
     public static MemberInfo toMemberInfo(Member member) {
 
-        return MemberInfo.builder()
-            .memberName(member.getEmail())
-            .profile(member.getProfile())
-            .major(member.getMajor().name())
-            .build();
+        return member == null ? null :
+            MemberInfo.builder()
+                .memberName(member.getEmail())
+                .profile(member.getProfile())
+                .major(member.getMajor().name())
+                .build();
     }
 }


### PR DESCRIPTION
## 요약

- 경험 카드 목록, 세부 정보, 추천 경험 카드 조회 API 구현

## 상세 내용

- 랜딩 페이지에 로그인 여부에 따른 추천 경험카드 구현
> 비로그인 : 랜덤으로 12개의 카드 응답
> 로그인 : 로그인 사용자의 직무에 따른 12개의 카드 응답
- Experience 정보를 바탕으로 경험 카드 정보 응답

## 질문 및 이외 사항

- 추후에 로그인 기능 merge 후 로그인 사용자 정보로 수정

## 이슈 번호

- close #17 
