### PR TITLE
Feat: 자기소개서 세부 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/analysis/Analysis.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/Analysis.java
@@ -1,6 +1,7 @@
 package com.codez4.meetfolio.domain.analysis;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,4 +31,8 @@ public class Analysis extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer satisfaction;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cover_letter_id", nullable = false)
+    private CoverLetter coverLetter;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/dto/AnalysisResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/dto/AnalysisResponse.java
@@ -1,0 +1,41 @@
+package com.codez4.meetfolio.domain.analysis.dto;
+
+import com.codez4.meetfolio.domain.analysis.Analysis;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AnalysisResponse {
+
+    @Schema(description = "AI 직무 역량 분석 결과 DTO")
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class AnalysisInfo {
+
+        @Schema(description = "직무 적합성 분석 결과")
+        private Double jobSuitability;
+
+        @Schema(description = "나의 역량 키워드 1")
+        private String keyword1;
+
+        @Schema(description = "나의 역량 키워드 2")
+        private String keyword2;
+
+        @Schema(description = "나의 역량 키워드 3")
+        private String keyword3;
+    }
+
+    public static AnalysisInfo toAnalysisInfo(Analysis analysis) {
+
+        return AnalysisInfo.builder()
+            .jobSuitability(analysis.getJobSuitability())
+            .keyword1(analysis.getKeyword1())
+            .keyword2(analysis.getKeyword2())
+            .keyword3(analysis.getKeyword3())
+            .build();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/repository/AnalysisRepository.java
@@ -1,0 +1,9 @@
+package com.codez4.meetfolio.domain.analysis.repository;
+
+import com.codez4.meetfolio.domain.analysis.Analysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
+
+    Analysis findByCoverLetterId(Long coverLetterId);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisQueryService.java
@@ -1,0 +1,24 @@
+package com.codez4.meetfolio.domain.analysis.service;
+
+import com.codez4.meetfolio.domain.analysis.Analysis;
+import com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse;
+import com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
+import com.codez4.meetfolio.domain.analysis.repository.AnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisQueryService {
+
+    private final AnalysisRepository analysisRepository;
+
+    public AnalysisInfo getAnalysisInfo(Long coverLetterId) {
+
+        Analysis analysis = analysisRepository.findByCoverLetterId(coverLetterId);
+
+        return AnalysisResponse.toAnalysisInfo(analysis);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -32,10 +32,6 @@ public class CoverLetter extends BaseTimeEntity {
     @Column(name = "cover_letter_id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
     @Column(nullable = false)
     private String question;
 
@@ -46,13 +42,18 @@ public class CoverLetter extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ShareType shareType;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private JobKeyword jobKeyword;
-
     @Column(name = "keyword_1")
     private String keyword1;
 
     @Column(name = "keyword_2")
     private String keyword2;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private JobKeyword jobKeyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -1,0 +1,46 @@
+package com.codez4.meetfolio.domain.coverLetter.controller;
+
+import com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
+import com.codez4.meetfolio.domain.analysis.service.AnalysisQueryService;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterInfo;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterResult;
+import com.codez4.meetfolio.domain.coverLetter.service.CoverLetterQueryService;
+import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
+import com.codez4.meetfolio.domain.feedback.service.FeedbackQueryService;
+import com.codez4.meetfolio.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "자기소개서 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coverLetters")
+public class CoverLetterController {
+
+    private final CoverLetterQueryService coverLetterQueryService;
+    private final FeedbackQueryService feedbackQueryService;
+    private final AnalysisQueryService analysisQueryService;
+
+
+    @Operation(summary = "자기소개서 상세정보 조회", description = "특정 자기소개서 정보를 조회합니다.")
+    @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @GetMapping("/{coverLetterId}")
+    public ApiResponse<CoverLetterResult> getCoverLetter(@PathVariable(name = "coverLetterId") Long coverLetterId) {
+
+        CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(coverLetterId);
+        FeedbackInfo feedbackInfo = feedbackQueryService.getFeedbackInfo(coverLetterId);
+        AnalysisInfo analysisInfo = analysisQueryService.getAnalysisInfo(coverLetterId);
+        CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(
+            coverLetterInfo, feedbackInfo, analysisInfo);
+
+        return ApiResponse.onSuccess(coverLetterResult);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -1,6 +1,10 @@
 package com.codez4.meetfolio.domain.coverLetter.dto;
 
+import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
+import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
+
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,17 +12,29 @@ import lombok.NoArgsConstructor;
 
 public class CoverLetterResponse {
 
+    @Schema(description = "자기소개서 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class CoverLetterInfo {
 
+        @Schema(description = "자기소개서 문항")
         private String question;
+
+        @Schema(description = "자기소개서 문항 답변")
         private String answer;
+
+        @Schema(description = "자기소개서 공유 여부")
         private String shareType;
+
+        @Schema(description = "강조하고 싶은 키워드 1")
         private String keyword1;
+
+        @Schema(description = "강조하고 싶은 키워드 2")
         private String keyword2;
+
+        @Schema(description = "지원 직무")
         private String jobKeyword;
     }
 
@@ -33,5 +49,26 @@ public class CoverLetterResponse {
             .jobKeyword(coverLetter.getJobKeyword().getDescription())
             .build();
 
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CoverLetterResult {
+
+        private CoverLetterInfo coverLetterInfo;
+        private FeedbackInfo feedbackInfo;
+        private AnalysisInfo analysisInfo;
+    }
+
+    public static CoverLetterResult toCoverLetterResult(CoverLetterInfo coverLetterInfo,
+        FeedbackInfo feedbackInfo, AnalysisInfo analysisInfo) {
+
+        return CoverLetterResult.builder()
+            .coverLetterInfo(coverLetterInfo)
+            .feedbackInfo(feedbackInfo)
+            .analysisInfo(analysisInfo)
+            .build();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -1,0 +1,37 @@
+package com.codez4.meetfolio.domain.coverLetter.dto;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CoverLetterResponse {
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CoverLetterInfo {
+
+        private String question;
+        private String answer;
+        private String shareType;
+        private String keyword1;
+        private String keyword2;
+        private String jobKeyword;
+    }
+
+    public static CoverLetterInfo toCoverLetterInfo(CoverLetter coverLetter) {
+
+        return CoverLetterInfo.builder()
+            .question(coverLetter.getQuestion())
+            .answer(coverLetter.getAnswer())
+            .shareType(coverLetter.getShareType().getDescription())
+            .keyword1(coverLetter.getKeyword1())
+            .keyword2(coverLetter.getKeyword2())
+            .jobKeyword(coverLetter.getJobKeyword().getDescription())
+            .build();
+
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
@@ -1,0 +1,8 @@
+package com.codez4.meetfolio.domain.coverLetter.repository;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
@@ -17,7 +17,7 @@ public class CoverLetterQueryService {
 
     private final CoverLetterRepository coverLetterRepository;
 
-    public CoverLetterInfo getCoverLetter(Long coverLetterId) {
+    public CoverLetterInfo getCoverLetterInfo(Long coverLetterId) {
 
         CoverLetter coverLetter = findById(coverLetterId);
         return CoverLetterResponse.toCoverLetterInfo(coverLetter);

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
@@ -1,0 +1,31 @@
+package com.codez4.meetfolio.domain.coverLetter.service;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterInfo;
+import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CoverLetterQueryService {
+
+    private final CoverLetterRepository coverLetterRepository;
+
+    public CoverLetterInfo getCoverLetter(Long coverLetterId) {
+
+        CoverLetter coverLetter = findById(coverLetterId);
+        return CoverLetterResponse.toCoverLetterInfo(coverLetter);
+    }
+
+    public CoverLetter findById(Long coverLetterId) {
+        return coverLetterRepository.findById(coverLetterId).orElseThrow(
+            () -> new ApiException(ErrorStatus._COVERLETTER_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
@@ -2,8 +2,19 @@ package com.codez4.meetfolio.domain.feedback;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -14,27 +25,27 @@ public class Feedback extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "solution_id",nullable = false)
+    @Column(name = "solution_id", nullable = false)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cover_letter_id", nullable = false)
     private CoverLetter coverLetter;
 
     // TODO : AI 기능 확정 후 수정 필요
-    @Column(name = "spell_check",nullable = false)
+    @Column(name = "spell_check", nullable = false)
     private String spellCheck;
 
     @Column(nullable = false)
     private String correction;
 
-    @Column(name="recommend_question_1",nullable = false)
+    @Column(name = "recommend_question_1", nullable = false)
     private String recommendQuestion1;
 
-    @Column(name="recommend_question_2",nullable = false)
+    @Column(name = "recommend_question_2", nullable = false)
     private String recommendQuestion2;
 
-    @Column(name="recommend_question_3",nullable = false)
+    @Column(name = "recommend_question_3", nullable = false)
     private String recommendQuestion3;
 
     @Column(nullable = false)

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/dto/FeedbackResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/dto/FeedbackResponse.java
@@ -1,0 +1,46 @@
+package com.codez4.meetfolio.domain.feedback.dto;
+
+import com.codez4.meetfolio.domain.feedback.Feedback;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FeedbackResponse {
+
+    @Schema(description = "AI 자기소개서 피드백 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class FeedbackInfo {
+
+        @Schema(description = "맞춤법 검사 결과")
+        private String spellCheck;
+
+        @Schema(description = "AI 피드백 결과")
+        private String correction;
+
+        @Schema(description = "추천 자기소개서 항목 1")
+        private String recommendQuestion1;
+
+        @Schema(description = "추천 자기소개서 항목 2")
+        private String recommendQuestion2;
+
+        @Schema(description = "추천 자기소개서 항목 3")
+        private String recommendQuestion3;
+
+    }
+
+    public static FeedbackInfo toFeedbackInfo(Feedback feedback) {
+
+        return FeedbackInfo.builder()
+            .spellCheck(feedback.getSpellCheck())
+            .correction(feedback.getCorrection())
+            .recommendQuestion1(feedback.getRecommendQuestion1())
+            .recommendQuestion2(feedback.getRecommendQuestion2())
+            .recommendQuestion3(feedback.getRecommendQuestion3())
+            .build();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.codez4.meetfolio.domain.feedback.repository;
+
+import com.codez4.meetfolio.domain.feedback.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    Feedback findByCoverLetterId(Long coverLetterId);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
@@ -1,0 +1,23 @@
+package com.codez4.meetfolio.domain.feedback.service;
+
+import com.codez4.meetfolio.domain.feedback.Feedback;
+import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse;
+import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
+import com.codez4.meetfolio.domain.feedback.repository.FeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedbackQueryService {
+
+    private final FeedbackRepository feedbackRepository;
+
+    public FeedbackInfo getFeedbackInfo(Long coverLetterId) {
+
+        Feedback feedback = feedbackRepository.findByCoverLetterId(coverLetterId);
+        return FeedbackResponse.toFeedbackInfo(feedback);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
@@ -25,7 +25,12 @@ public enum ErrorStatus implements BaseErrorCode {
     // ================================================================================================================= //
 
     // 경험 분해 관련
-    _EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXPERIENCE4001", "존재하지 않는 경험 분해 데이터입니다.");
+    _EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXPERIENCE4001", "존재하지 않는 경험 분해 데이터입니다."),
+
+    // ================================================================================================================= //
+
+    // 자기소개서 관련
+    _COVERLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "COVERLETTER4001", "존재하지 않는 자기소개서 데이터입니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 요약

- 자기소개서 세부 정보 조회 API 구현

## 상세 내용

- 작성한 자기소개서와 AI 피드백, 직무 역량 분석 결과를 조회합니다.

<img width="233" alt="image" src="https://github.com/Meetfolio-Project-CodeZ-Team/Backend/assets/103489352/12acc07c-d8ba-4333-a889-71eefc690ef6">


## 질문 및 이외 사항

- 로그인 기능 구현으로 인해, Merge한 후 자기소개서 추가 기능을 구현하려고 합니다.

## 이슈 번호

- close #18 
