### PR TITLE
Feat: 자기소개서 작성, 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/analysis/Analysis.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/Analysis.java
@@ -2,8 +2,10 @@ package com.codez4.meetfolio.domain.analysis;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.Status;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -35,4 +37,16 @@ public class Analysis extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cover_letter_id", nullable = false)
     private CoverLetter coverLetter;
+
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    /**
+     * update
+     */
+    public void delete() {
+        this.status = Status.INACTIVE;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisCommandService.java
@@ -1,0 +1,17 @@
+package com.codez4.meetfolio.domain.analysis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AnalysisCommandService {
+
+    private final AnalysisQueryService analysisQueryService;
+
+    public void softDelete(Long coverLetterId) {
+        analysisQueryService.findByCoverLetterId(coverLetterId).delete();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisQueryService.java
@@ -17,8 +17,10 @@ public class AnalysisQueryService {
 
     public AnalysisInfo getAnalysisInfo(Long coverLetterId) {
 
-        Analysis analysis = analysisRepository.findByCoverLetterId(coverLetterId);
+        return AnalysisResponse.toAnalysisInfo(findByCoverLetterId(coverLetterId));
+    }
 
-        return AnalysisResponse.toAnalysisInfo(analysis);
+    public Analysis findByCoverLetterId(Long coverLetterId) {
+        return analysisRepository.findByCoverLetterId(coverLetterId);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -1,6 +1,7 @@
 package com.codez4.meetfolio.domain.coverLetter;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.ShareType;
 import com.codez4.meetfolio.domain.member.Member;
@@ -56,4 +57,15 @@ public class CoverLetter extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    /**
+     * update
+     */
+    public void update(CoverLetterRequest request) {
+        this.question = request.getQuestion();
+        this.answer = request.getAnswer();
+        this.shareType = ShareType.convert(request.getShareType());
+        this.keyword1 = request.getKeyword1();
+        this.keyword2 = request.getKeyword2();
+        this.jobKeyword = JobKeyword.convert(request.getJobKeyword());
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -4,6 +4,7 @@ import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.ShareType;
+import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -53,6 +55,11 @@ public class CoverLetter extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private JobKeyword jobKeyword;
 
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -68,4 +75,9 @@ public class CoverLetter extends BaseTimeEntity {
         this.keyword2 = request.getKeyword2();
         this.jobKeyword = JobKeyword.convert(request.getJobKeyword());
     }
+
+    public void delete() {
+        this.status = Status.INACTIVE;
+    }
+
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,5 +72,14 @@ public class CoverLetterController {
         @Valid @RequestBody CoverLetterRequest request) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.update(coverLetterId, request));
+    }
+
+    @Operation(summary = "자기소개서 삭제 요청", description = "특정 자기소개서 정보를 삭제합니다.")
+    @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @DeleteMapping("/{coverLetterId}")
+    public ApiResponse<CoverLetterProc> deleteCoverLetter(
+        @PathVariable(name = "coverLetterId") Long coverLetterId) {
+
+        return ApiResponse.onSuccess(coverLetterCommandService.delete(coverLetterId));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -2,20 +2,28 @@ package com.codez4.meetfolio.domain.coverLetter.controller;
 
 import com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
 import com.codez4.meetfolio.domain.analysis.service.AnalysisQueryService;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterInfo;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterProc;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterResult;
+import com.codez4.meetfolio.domain.coverLetter.service.CoverLetterCommandService;
 import com.codez4.meetfolio.domain.coverLetter.service.CoverLetterQueryService;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 import com.codez4.meetfolio.domain.feedback.service.FeedbackQueryService;
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CoverLetterController {
 
     private final CoverLetterQueryService coverLetterQueryService;
+    private final CoverLetterCommandService coverLetterCommandService;
     private final FeedbackQueryService feedbackQueryService;
     private final AnalysisQueryService analysisQueryService;
 
@@ -33,7 +42,8 @@ public class CoverLetterController {
     @Operation(summary = "자기소개서 상세정보 조회", description = "특정 자기소개서 정보를 조회합니다.")
     @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/{coverLetterId}")
-    public ApiResponse<CoverLetterResult> getCoverLetter(@PathVariable(name = "coverLetterId") Long coverLetterId) {
+    public ApiResponse<CoverLetterResult> getCoverLetter(
+        @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
         CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(coverLetterId);
         FeedbackInfo feedbackInfo = feedbackQueryService.getFeedbackInfo(coverLetterId);
@@ -42,5 +52,13 @@ public class CoverLetterController {
             coverLetterInfo, feedbackInfo, analysisInfo);
 
         return ApiResponse.onSuccess(coverLetterResult);
+    }
+
+    @Operation(summary = "자기소개서 작성 요청", description = "로그인 사용자는 자기소개서를 작성합니다.")
+    @PostMapping
+    public ApiResponse<CoverLetterProc> createCoverLetter(@AuthenticationMember Member member,
+        @Valid @RequestBody CoverLetterRequest request) {
+
+        return ApiResponse.onSuccess(coverLetterCommandService.write(member, request));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -12,6 +12,8 @@ import com.codez4.meetfolio.domain.coverLetter.service.CoverLetterQueryService;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 import com.codez4.meetfolio.domain.feedback.service.FeedbackQueryService;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,13 +46,14 @@ public class CoverLetterController {
     @Operation(summary = "자기소개서 상세정보 조회", description = "특정 자기소개서 정보를 조회합니다.")
     @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/{coverLetterId}")
-    public ApiResponse<CoverLetterResult> getCoverLetter(
+    public ApiResponse<CoverLetterResult> getCoverLetter(@AuthenticationMember Member member,
         @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(coverLetterId);
         FeedbackInfo feedbackInfo = feedbackQueryService.getFeedbackInfo(coverLetterId);
         AnalysisInfo analysisInfo = analysisQueryService.getAnalysisInfo(coverLetterId);
-        CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(
+        CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(memberInfo,
             coverLetterInfo, feedbackInfo, analysisInfo);
 
         return ApiResponse.onSuccess(coverLetterResult);

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,5 +61,15 @@ public class CoverLetterController {
         @Valid @RequestBody CoverLetterRequest request) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.write(member, request));
+    }
+
+    @Operation(summary = "자기소개서 수정 요청", description = "특정 자기소개서 정보를 수정합니다.")
+    @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @PatchMapping("/{coverLetterId}")
+    public ApiResponse<CoverLetterProc> updateCoverLetter(
+        @PathVariable(name = "coverLetterId") Long coverLetterId,
+        @Valid @RequestBody CoverLetterRequest request) {
+
+        return ApiResponse.onSuccess(coverLetterCommandService.update(coverLetterId, request));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -83,6 +83,6 @@ public class CoverLetterController {
     public ApiResponse<CoverLetterProc> deleteCoverLetter(
         @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
-        return ApiResponse.onSuccess(coverLetterCommandService.delete(coverLetterId));
+        return ApiResponse.onSuccess(coverLetterCommandService.softDelete(coverLetterId));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
@@ -1,0 +1,47 @@
+package com.codez4.meetfolio.domain.coverLetter.dto;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.enums.ShareType;
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.annotation.EnumValid;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "자기소개서 작성 & 수정 DTO")
+@Getter
+public class CoverLetterRequest {
+
+    @Schema(description = "자기소개서 문항")
+    private String question;
+
+    @Schema(description = "자기소개서 답변")
+    private String answer;
+
+    @Schema(description = "자기소개서 공개 여부")
+    @EnumValid(enumClass = ShareType.class)
+    private String shareType;
+
+    @Schema(description = "나의 역량 키워드 1")
+    private String keyword1;
+
+    @Schema(description = "나의 역량 키워드 2")
+    private String keyword2;
+
+    @Schema(description = "자기소개서 지원 직무")
+    @EnumValid(enumClass = JobKeyword.class)
+    private String jobKeyword;
+
+    public static CoverLetter toEntity(Member member, CoverLetterRequest request) {
+
+        return CoverLetter.builder()
+            .question(request.getQuestion())
+            .answer(request.getAnswer())
+            .shareType(ShareType.convert(request.getShareType()))
+            .keyword1(request.getKeyword1())
+            .keyword2(request.getKeyword2())
+            .jobKeyword(JobKeyword.convert(request.getJobKeyword()))
+            .member(member)
+            .build();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
@@ -18,7 +18,7 @@ public class CoverLetterRequest {
     @Schema(description = "자기소개서 답변")
     private String answer;
 
-    @Schema(description = "자기소개서 공개 여부")
+    @Schema(description = "자기소개서 공개 여부", example = "PUBLIC")
     @EnumValid(enumClass = ShareType.class)
     private String shareType;
 
@@ -28,7 +28,7 @@ public class CoverLetterRequest {
     @Schema(description = "나의 역량 키워드 2")
     private String keyword2;
 
-    @Schema(description = "자기소개서 지원 직무")
+    @Schema(description = "자기소개서 지원 직무", example = "BACKEND")
     @EnumValid(enumClass = JobKeyword.class)
     private String jobKeyword;
 

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -73,13 +73,17 @@ public class CoverLetterResponse {
             .build();
     }
 
+    @Schema(description = "자기소개서 작성 & 수정 & 삭제 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class CoverLetterProc {
 
+        @Schema(description = "자기소개서 아이디")
         private Long coverLetterId;
+
+        @Schema(description = "응답 처리 완료된 시간")
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -4,6 +4,7 @@ import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.Analysis
 import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -52,21 +53,25 @@ public class CoverLetterResponse {
 
     }
 
+    @Schema(description = "자기소개서 세부 정보 조회 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class CoverLetterResult {
 
+        private MemberInfo memberInfo;
         private CoverLetterInfo coverLetterInfo;
         private FeedbackInfo feedbackInfo;
         private AnalysisInfo analysisInfo;
     }
 
-    public static CoverLetterResult toCoverLetterResult(CoverLetterInfo coverLetterInfo,
+    public static CoverLetterResult toCoverLetterResult(MemberInfo memberInfo,
+        CoverLetterInfo coverLetterInfo,
         FeedbackInfo feedbackInfo, AnalysisInfo analysisInfo) {
 
         return CoverLetterResult.builder()
+            .memberInfo(memberInfo)
             .coverLetterInfo(coverLetterInfo)
             .feedbackInfo(feedbackInfo)
             .analysisInfo(analysisInfo)

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -5,6 +5,7 @@ import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.Feedback
 
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,6 +70,23 @@ public class CoverLetterResponse {
             .coverLetterInfo(coverLetterInfo)
             .feedbackInfo(feedbackInfo)
             .analysisInfo(analysisInfo)
+            .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CoverLetterProc {
+
+        private Long coverLetterId;
+        private LocalDateTime createdAt;
+    }
+
+    public static CoverLetterProc toCoverLetterProc(Long coverLetterId) {
+        return CoverLetterProc.builder()
+            .coverLetterId(coverLetterId)
+            .createdAt(LocalDateTime.now())
             .build();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -1,0 +1,31 @@
+package com.codez4.meetfolio.domain.coverLetter.service;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterProc;
+import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoverLetterCommandService {
+
+    private final CoverLetterRepository coverLetterRepository;
+
+    public CoverLetterProc write(Member member, CoverLetterRequest request) {
+
+        CoverLetter coverLetter = save(CoverLetterRequest.toEntity(member, request));
+
+        return CoverLetterResponse.toCoverLetterProc(coverLetter.getId());
+
+    }
+
+    public CoverLetter save(CoverLetter coverLetter) {
+        return coverLetterRepository.save(coverLetter);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -1,10 +1,12 @@
 package com.codez4.meetfolio.domain.coverLetter.service;
 
+import com.codez4.meetfolio.domain.analysis.service.AnalysisCommandService;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterProc;
 import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.domain.feedback.service.FeedbackCommandService;
 import com.codez4.meetfolio.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,8 @@ public class CoverLetterCommandService {
 
     private final CoverLetterRepository coverLetterRepository;
     private final CoverLetterQueryService coverLetterQueryService;
+    private final AnalysisCommandService analysisCommandService;
+    private final FeedbackCommandService feedbackCommandService;
 
     public CoverLetterProc write(Member member, CoverLetterRequest request) {
 
@@ -36,12 +40,11 @@ public class CoverLetterCommandService {
         return CoverLetterResponse.toCoverLetterProc(coverLetterId);
     }
 
-    public CoverLetterProc delete(Long coverLetterId) {
-        deleteById(coverLetterId);
+    public CoverLetterProc softDelete(Long coverLetterId) {
+        coverLetterQueryService.findById(coverLetterId).delete();
+        analysisCommandService.softDelete(coverLetterId);
+        feedbackCommandService.softDelete(coverLetterId);
         return CoverLetterResponse.toCoverLetterProc(coverLetterId);
     }
 
-    private void deleteById(Long coverLetterId) {
-        coverLetterRepository.deleteById(coverLetterId);
-    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CoverLetterCommandService {
 
     private final CoverLetterRepository coverLetterRepository;
+    private final CoverLetterQueryService coverLetterQueryService;
 
     public CoverLetterProc write(Member member, CoverLetterRequest request) {
 
@@ -27,5 +28,11 @@ public class CoverLetterCommandService {
 
     public CoverLetter save(CoverLetter coverLetter) {
         return coverLetterRepository.save(coverLetter);
+    }
+
+    public CoverLetterProc update(Long coverLetterId, CoverLetterRequest request) {
+        CoverLetter coverLetter = coverLetterQueryService.findById(coverLetterId);
+        coverLetter.update(request);
+        return CoverLetterResponse.toCoverLetterProc(coverLetterId);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -26,7 +26,7 @@ public class CoverLetterCommandService {
 
     }
 
-    public CoverLetter save(CoverLetter coverLetter) {
+    private CoverLetter save(CoverLetter coverLetter) {
         return coverLetterRepository.save(coverLetter);
     }
 
@@ -34,5 +34,14 @@ public class CoverLetterCommandService {
         CoverLetter coverLetter = coverLetterQueryService.findById(coverLetterId);
         coverLetter.update(request);
         return CoverLetterResponse.toCoverLetterProc(coverLetterId);
+    }
+
+    public CoverLetterProc delete(Long coverLetterId) {
+        deleteById(coverLetterId);
+        return CoverLetterResponse.toCoverLetterProc(coverLetterId);
+    }
+
+    private void deleteById(Long coverLetterId) {
+        coverLetterRepository.deleteById(coverLetterId);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/enums/ShareType.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/ShareType.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +13,15 @@ public enum ShareType {
     ;
 
     private final String description;
+
+    @JsonCreator
+    public static ShareType convert(String source)
+    {
+        for (ShareType shareType : ShareType.values()) {
+            if (shareType.name().equals(source)) {
+                return shareType;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -17,7 +17,7 @@ import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
-import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,14 +43,11 @@ public class ExperienceController {
 
     private final ExperienceQueryService experienceQueryService;
     private final ExperienceCommandService experienceCommandService;
-    private final MemberQueryService memberQueryService;
 
     @Operation(summary = "랜딩 페이지 - 추천 카드 12개 조회", description = "비로그인 사용자는 랜덤 12개, 로그인 사용자는 희망 직무에 따라 12개 추천")
     @GetMapping
-    public ApiResponse<RecommendCard> recommendCard() {
+    public ApiResponse<RecommendCard> recommendCard(@AuthenticationMember Member member) {
 
-        // TODO: 추후 로그인 사용자로 변경
-        Member member = memberQueryService.findById(1L);
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         List<ExperienceCardItem> recommendCardInfo = experienceQueryService.getRecommendCard(
             member);
@@ -62,11 +58,10 @@ public class ExperienceController {
     @Operation(summary = "경험 분해 상세정보 조회", description = "특정 경험 분해 정보를 조회합니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/experiences/{experienceId}")
-    public ApiResponse<ExperienceResult> getExperience(
+    public ApiResponse<ExperienceResult> getExperience(@AuthenticationMember Member member,
         @PathVariable(name = "experienceId") Long experienceId) {
 
-        // TODO: 추후 로그인 사용자로 수정
-        MemberInfo memberInfo = memberQueryService.getMemberInfo(1L);
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         ExperienceInfo experienceInfo = experienceQueryService.getExperience(experienceId);
 
         return ApiResponse.onSuccess(toExperienceResult(memberInfo, experienceInfo));
@@ -74,10 +69,8 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 작성", description = "경험 분해 작성 요청을 POST로 보냅니다.")
     @PostMapping("/experiences")
-    public ApiResponse<ExperienceProc> post(@RequestBody ExperienceRequest post) {
-
-        // TODO: 추후 로그인 사용자로 수정 - 1L
-        Member member = memberQueryService.findById(1L);
+    public ApiResponse<ExperienceProc> post(@AuthenticationMember Member member,
+        @RequestBody ExperienceRequest post) {
 
         return ApiResponse.onSuccess(experienceCommandService.post(post, member));
     }
@@ -103,12 +96,10 @@ public class ExperienceController {
     @Operation(summary = "경험 카드 목록 조회", description = "경험 카드 목록(Paging) 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/experience-cards")
-    public ApiResponse<ExperienceCardResult> getExperienceCards(
+    public ApiResponse<ExperienceCardResult> getExperienceCards(@AuthenticationMember Member member,
         @RequestParam(value = "page", defaultValue = "0") int page) {
 
-        // TODO: 추후 로그인 사용자로 변경 - 1L
-        Member member = memberQueryService.findById(1L);
-        MemberInfo memberInfo = memberQueryService.getMemberInfo(1L);
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
 
         ExperienceCardInfo experienceCardInfo = experienceQueryService.getExperienceCardInfo(member,
             page);

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceRequest.java
@@ -3,6 +3,7 @@ package com.codez4.meetfolio.domain.experience.dto;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.annotation.EnumValid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class ExperienceRequest {
     private String motivation;
 
     @Schema(description = "맡았던 직무", example = "BACKEND")
+    @EnumValid(enumClass = JobKeyword.class)
     private String jobKeyword;
 
     @Schema(description = "사용한 기술 스택", example = "spring/mysql")

--- a/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceCommandService.java
@@ -20,7 +20,6 @@ public class ExperienceCommandService {
 
     public ExperienceProc post(ExperienceRequest post, Member member) {
 
-        // TODO: 로그인 사용자로 추후 수정
         Experience experience = experienceRepository.save(ExperienceRequest.toEntity(post, member));
 
         return ExperienceResponse.toExperienceProc(experience.getId());

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
@@ -2,19 +2,24 @@ package com.codez4.meetfolio.domain.feedback;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.Status;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PostUpdate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -50,4 +55,16 @@ public class Feedback extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer satisfaction;
+
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    /**
+     * update
+     */
+    public void delete() {
+        this.status = Status.INACTIVE;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackCommandService.java
@@ -1,0 +1,17 @@
+package com.codez4.meetfolio.domain.feedback.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedbackCommandService {
+
+    private final FeedbackQueryService feedbackQueryService;
+
+    public void softDelete(Long coverLetterId) {
+        feedbackQueryService.findByCoverLetterId(coverLetterId).delete();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
@@ -4,6 +4,8 @@ import com.codez4.meetfolio.domain.feedback.Feedback;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 import com.codez4.meetfolio.domain.feedback.repository.FeedbackRepository;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +19,9 @@ public class FeedbackQueryService {
 
     public FeedbackInfo getFeedbackInfo(Long coverLetterId) {
 
-        Feedback feedback = feedbackRepository.findByCoverLetterId(coverLetterId);
-        return FeedbackResponse.toFeedbackInfo(feedback);
+        return FeedbackResponse.toFeedbackInfo(findByCoverLetterId(coverLetterId));
+    }
+    public Feedback findByCoverLetterId(Long coverLetterId) {
+        return feedbackRepository.findByCoverLetterId(coverLetterId);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -1,20 +1,18 @@
 package com.codez4.meetfolio.domain.member.service;
 
+import static com.codez4.meetfolio.global.security.Password.ENCODER;
+
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.LoginRequest;
-import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import com.codez4.meetfolio.domain.member.repository.MemberRepository;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.codez4.meetfolio.global.security.Password;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Optional;
-
-import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
-import static com.codez4.meetfolio.global.security.Password.ENCODER;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +24,7 @@ public class MemberQueryService {
 
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(
-                () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
         );
     }
 
@@ -35,14 +33,12 @@ public class MemberQueryService {
         return member;
     }
 
-    public MemberInfo getMemberInfo(Long memberId) {
-        return toMemberInfo(findById(memberId));
-    }
-
     public String login(LoginRequest request) {
-        Member member = findByEmail(request.getEmail()).orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
+        Member member = findByEmail(request.getEmail()).orElseThrow(
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
         comparePassword(request.getPassword(), member.getPassword());
-        String token = jwtTokenProvider.generate(member.getEmail(), member.getId(), member.getAuthority());
+        String token = jwtTokenProvider.generate(member.getEmail(), member.getId(),
+            member.getAuthority());
         return token;
     }
 

--- a/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
+++ b/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     private final JwtExceptionFilter jwtExceptionFilter;
     private static final String[] WHITE_LIST_URL = {
             // application
+            "/api",
             "/api/login",
             "/api/signup",
             "/api/signup/email",

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtAuthenticationFilter.java
@@ -38,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || request.getServletPath().contains("/swagger-ui")
                 || request.getServletPath().contains("/swagger-resources")
                 || request.getServletPath().contains("v3/api-docs")
+                || request.getServletPath().equals("/api")
         ) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
@@ -40,7 +40,16 @@ public enum ErrorStatus implements BaseErrorCode {
     // ================================================================================================================= //
 
     // 자기소개서 관련
-    _COVERLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "COVERLETTER4001", "존재하지 않는 자기소개서 데이터입니다.");
+    _COVERLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "COVERLETTER4001", "존재하지 않는 자기소개서 데이터입니다."),
+
+    // ================================================================================================================= //
+
+    // AI 피드백 관련
+    _FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "FEEDBACK4001", "존재하지 않는 피드백 데이터입니다."),
+    // ================================================================================================================= //
+
+    // AI 직무 역량 분석 관련
+    _ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS4001", "존재하지 않는 AI 직무 역량 분석 데이터입니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 요약

- 자기소개서 작성, 수정, 삭제 API 구현

## 상세 내용

- 자기소개서 작성, 수정, 삭제 API 구현
- @EnumValid, Enum.convert 적용
- 로그인 사용자 정보 반영

## 질문 및 이외 사항

- @joowojr 자기소개서 삭제할 시 연관된 feedback, analysis 엔티티도 함께 제거할 건지,
> 만약 제거된다면 AI 서비스 통계와도 연관돼서 이야기 해봐야 될 것같음

## 이슈 번호

- close #26 
