### PR TITLE
Feat : 관리자 회원 관리 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/analysis/Analysis.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/Analysis.java
@@ -2,8 +2,10 @@ package com.codez4.meetfolio.domain.analysis;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.Status;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -35,4 +37,16 @@ public class Analysis extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cover_letter_id", nullable = false)
     private CoverLetter coverLetter;
+
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    /**
+     * update
+     */
+    public void delete() {
+        this.status = Status.INACTIVE;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisCommandService.java
@@ -1,0 +1,17 @@
+package com.codez4.meetfolio.domain.analysis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AnalysisCommandService {
+
+    private final AnalysisQueryService analysisQueryService;
+
+    public void softDelete(Long coverLetterId) {
+        analysisQueryService.findByCoverLetterId(coverLetterId).delete();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/analysis/service/AnalysisQueryService.java
@@ -17,8 +17,10 @@ public class AnalysisQueryService {
 
     public AnalysisInfo getAnalysisInfo(Long coverLetterId) {
 
-        Analysis analysis = analysisRepository.findByCoverLetterId(coverLetterId);
+        return AnalysisResponse.toAnalysisInfo(findByCoverLetterId(coverLetterId));
+    }
 
-        return AnalysisResponse.toAnalysisInfo(analysis);
+    public Analysis findByCoverLetterId(Long coverLetterId) {
+        return analysisRepository.findByCoverLetterId(coverLetterId);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/Board.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/Board.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.board;
 
+import com.codez4.meetfolio.domain.comment.Comment;
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.member.Member;
 import jakarta.persistence.*;
@@ -9,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+
+import java.util.List;
 
 @DynamicInsert
 @Getter
@@ -42,5 +45,6 @@ public class Board extends BaseTimeEntity {
     @ColumnDefault("'0'")
     private Integer commentCount;
 
-
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/Board.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/Board.java
@@ -2,6 +2,7 @@ package com.codez4.meetfolio.domain.board;
 
 import com.codez4.meetfolio.domain.comment.Comment;
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
+import com.codez4.meetfolio.domain.like.Like;
 import com.codez4.meetfolio.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -44,6 +45,9 @@ public class Board extends BaseTimeEntity {
     @Column(name = "comment_count", nullable = false)
     @ColumnDefault("'0'")
     private Integer commentCount;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments;

--- a/src/main/java/com/codez4/meetfolio/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/repository/BoardRepository.java
@@ -1,0 +1,11 @@
+package com.codez4.meetfolio.domain.board.repository;
+
+import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board,Long> {
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.codez4.meetfolio.domain.comment.repository;
+
+import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.comment.Comment;
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+
+    void deleteByParentComment_Member(Member parentComment_member);
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,5 @@
 package com.codez4.meetfolio.domain.comment.repository;
 
-import com.codez4.meetfolio.domain.board.Board;
 import com.codez4.meetfolio.domain.comment.Comment;
 import com.codez4.meetfolio.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment,Long> {
 
-    void deleteByParentComment_Member(Member parentComment_member);
     void deleteByMember(Member member);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/codez4/meetfolio/domain/common/BaseTimeEntity.java
@@ -3,11 +3,12 @@ package com.codez4.meetfolio.domain.common;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -6,21 +6,8 @@ import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.ShareType;
 import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.member.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 @Getter

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -1,8 +1,10 @@
 package com.codez4.meetfolio.domain.coverLetter;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.ShareType;
+import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -52,8 +55,29 @@ public class CoverLetter extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private JobKeyword jobKeyword;
 
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    /**
+     * update
+     */
+    public void update(CoverLetterRequest request) {
+        this.question = request.getQuestion();
+        this.answer = request.getAnswer();
+        this.shareType = ShareType.convert(request.getShareType());
+        this.keyword1 = request.getKeyword1();
+        this.keyword2 = request.getKeyword2();
+        this.jobKeyword = JobKeyword.convert(request.getJobKeyword());
+    }
+
+    public void delete() {
+        this.status = Status.INACTIVE;
+    }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -2,20 +2,32 @@ package com.codez4.meetfolio.domain.coverLetter.controller;
 
 import com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
 import com.codez4.meetfolio.domain.analysis.service.AnalysisQueryService;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterInfo;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterProc;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterResult;
+import com.codez4.meetfolio.domain.coverLetter.service.CoverLetterCommandService;
 import com.codez4.meetfolio.domain.coverLetter.service.CoverLetterQueryService;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 import com.codez4.meetfolio.domain.feedback.service.FeedbackQueryService;
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CoverLetterController {
 
     private final CoverLetterQueryService coverLetterQueryService;
+    private final CoverLetterCommandService coverLetterCommandService;
     private final FeedbackQueryService feedbackQueryService;
     private final AnalysisQueryService analysisQueryService;
 
@@ -33,14 +46,43 @@ public class CoverLetterController {
     @Operation(summary = "자기소개서 상세정보 조회", description = "특정 자기소개서 정보를 조회합니다.")
     @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/{coverLetterId}")
-    public ApiResponse<CoverLetterResult> getCoverLetter(@PathVariable(name = "coverLetterId") Long coverLetterId) {
+    public ApiResponse<CoverLetterResult> getCoverLetter(@AuthenticationMember Member member,
+        @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(coverLetterId);
         FeedbackInfo feedbackInfo = feedbackQueryService.getFeedbackInfo(coverLetterId);
         AnalysisInfo analysisInfo = analysisQueryService.getAnalysisInfo(coverLetterId);
-        CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(
+        CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(memberInfo,
             coverLetterInfo, feedbackInfo, analysisInfo);
 
         return ApiResponse.onSuccess(coverLetterResult);
+    }
+
+    @Operation(summary = "자기소개서 작성 요청", description = "로그인 사용자는 자기소개서를 작성합니다.")
+    @PostMapping
+    public ApiResponse<CoverLetterProc> createCoverLetter(@AuthenticationMember Member member,
+        @Valid @RequestBody CoverLetterRequest request) {
+
+        return ApiResponse.onSuccess(coverLetterCommandService.write(member, request));
+    }
+
+    @Operation(summary = "자기소개서 수정 요청", description = "특정 자기소개서 정보를 수정합니다.")
+    @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @PatchMapping("/{coverLetterId}")
+    public ApiResponse<CoverLetterProc> updateCoverLetter(
+        @PathVariable(name = "coverLetterId") Long coverLetterId,
+        @Valid @RequestBody CoverLetterRequest request) {
+
+        return ApiResponse.onSuccess(coverLetterCommandService.update(coverLetterId, request));
+    }
+
+    @Operation(summary = "자기소개서 삭제 요청", description = "특정 자기소개서 정보를 삭제합니다.")
+    @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @DeleteMapping("/{coverLetterId}")
+    public ApiResponse<CoverLetterProc> deleteCoverLetter(
+        @PathVariable(name = "coverLetterId") Long coverLetterId) {
+
+        return ApiResponse.onSuccess(coverLetterCommandService.softDelete(coverLetterId));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -22,14 +22,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "자기소개서 API")
 @RestController

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
@@ -1,0 +1,47 @@
+package com.codez4.meetfolio.domain.coverLetter.dto;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.enums.ShareType;
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.annotation.EnumValid;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "자기소개서 작성 & 수정 DTO")
+@Getter
+public class CoverLetterRequest {
+
+    @Schema(description = "자기소개서 문항")
+    private String question;
+
+    @Schema(description = "자기소개서 답변")
+    private String answer;
+
+    @Schema(description = "자기소개서 공개 여부", example = "PUBLIC")
+    @EnumValid(enumClass = ShareType.class)
+    private String shareType;
+
+    @Schema(description = "나의 역량 키워드 1")
+    private String keyword1;
+
+    @Schema(description = "나의 역량 키워드 2")
+    private String keyword2;
+
+    @Schema(description = "자기소개서 지원 직무", example = "BACKEND")
+    @EnumValid(enumClass = JobKeyword.class)
+    private String jobKeyword;
+
+    public static CoverLetter toEntity(Member member, CoverLetterRequest request) {
+
+        return CoverLetter.builder()
+            .question(request.getQuestion())
+            .answer(request.getAnswer())
+            .shareType(ShareType.convert(request.getShareType()))
+            .keyword1(request.getKeyword1())
+            .keyword2(request.getKeyword2())
+            .jobKeyword(JobKeyword.convert(request.getJobKeyword()))
+            .member(member)
+            .build();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -4,7 +4,9 @@ import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.Analysis
 import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,24 +53,49 @@ public class CoverLetterResponse {
 
     }
 
+    @Schema(description = "자기소개서 세부 정보 조회 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
     public static class CoverLetterResult {
 
+        private MemberInfo memberInfo;
         private CoverLetterInfo coverLetterInfo;
         private FeedbackInfo feedbackInfo;
         private AnalysisInfo analysisInfo;
     }
 
-    public static CoverLetterResult toCoverLetterResult(CoverLetterInfo coverLetterInfo,
+    public static CoverLetterResult toCoverLetterResult(MemberInfo memberInfo,
+        CoverLetterInfo coverLetterInfo,
         FeedbackInfo feedbackInfo, AnalysisInfo analysisInfo) {
 
         return CoverLetterResult.builder()
+            .memberInfo(memberInfo)
             .coverLetterInfo(coverLetterInfo)
             .feedbackInfo(feedbackInfo)
             .analysisInfo(analysisInfo)
+            .build();
+    }
+
+    @Schema(description = "자기소개서 작성 & 수정 & 삭제 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CoverLetterProc {
+
+        @Schema(description = "자기소개서 아이디")
+        private Long coverLetterId;
+
+        @Schema(description = "응답 처리 완료된 시간")
+        private LocalDateTime createdAt;
+    }
+
+    public static CoverLetterProc toCoverLetterProc(Long coverLetterId) {
+        return CoverLetterProc.builder()
+            .coverLetterId(coverLetterId)
+            .createdAt(LocalDateTime.now())
             .build();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -1,16 +1,17 @@
 package com.codez4.meetfolio.domain.coverLetter.dto;
 
-import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
-import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
-
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
+import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 
 public class CoverLetterResponse {
 

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
@@ -1,8 +1,9 @@
 package com.codez4.meetfolio.domain.coverLetter.repository;
 
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
-
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
@@ -4,5 +4,8 @@ import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
+    List<CoverLetter> findByMember(Member member);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
@@ -5,5 +5,4 @@ import com.codez4.meetfolio.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
-    void deleteByMember(Member member);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -1,0 +1,50 @@
+package com.codez4.meetfolio.domain.coverLetter.service;
+
+import com.codez4.meetfolio.domain.analysis.service.AnalysisCommandService;
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterProc;
+import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.domain.feedback.service.FeedbackCommandService;
+import com.codez4.meetfolio.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoverLetterCommandService {
+
+    private final CoverLetterRepository coverLetterRepository;
+    private final CoverLetterQueryService coverLetterQueryService;
+    private final AnalysisCommandService analysisCommandService;
+    private final FeedbackCommandService feedbackCommandService;
+
+    public CoverLetterProc write(Member member, CoverLetterRequest request) {
+
+        CoverLetter coverLetter = save(CoverLetterRequest.toEntity(member, request));
+
+        return CoverLetterResponse.toCoverLetterProc(coverLetter.getId());
+
+    }
+
+    private CoverLetter save(CoverLetter coverLetter) {
+        return coverLetterRepository.save(coverLetter);
+    }
+
+    public CoverLetterProc update(Long coverLetterId, CoverLetterRequest request) {
+        CoverLetter coverLetter = coverLetterQueryService.findById(coverLetterId);
+        coverLetter.update(request);
+        return CoverLetterResponse.toCoverLetterProc(coverLetterId);
+    }
+
+    public CoverLetterProc softDelete(Long coverLetterId) {
+        coverLetterQueryService.findById(coverLetterId).delete();
+        analysisCommandService.softDelete(coverLetterId);
+        feedbackCommandService.softDelete(coverLetterId);
+        return CoverLetterResponse.toCoverLetterProc(coverLetterId);
+    }
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/enums/Authority.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/Authority.java
@@ -1,7 +1,15 @@
 package com.codez4.meetfolio.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Authority {
 
-    MEMBER, ADMIN;
+    MEMBER("ROLE_MEMBER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String description;
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/enums/ShareType.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/ShareType.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +13,15 @@ public enum ShareType {
     ;
 
     private final String description;
+
+    @JsonCreator
+    public static ShareType convert(String source)
+    {
+        for (ShareType shareType : ShareType.values()) {
+            if (shareType.name().equals(source)) {
+                return shareType;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/Experience.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/Experience.java
@@ -4,22 +4,10 @@ import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceRequest;
 import com.codez4.meetfolio.domain.member.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDate;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Entity

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -17,7 +17,7 @@ import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
-import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,14 +43,11 @@ public class ExperienceController {
 
     private final ExperienceQueryService experienceQueryService;
     private final ExperienceCommandService experienceCommandService;
-    private final MemberQueryService memberQueryService;
 
     @Operation(summary = "랜딩 페이지 - 추천 카드 12개 조회", description = "비로그인 사용자는 랜덤 12개, 로그인 사용자는 희망 직무에 따라 12개 추천")
     @GetMapping
-    public ApiResponse<RecommendCard> recommendCard() {
+    public ApiResponse<RecommendCard> recommendCard(@AuthenticationMember Member member) {
 
-        // TODO: 추후 로그인 사용자로 변경
-        Member member = memberQueryService.findById(1L);
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         List<ExperienceCardItem> recommendCardInfo = experienceQueryService.getRecommendCard(
             member);
@@ -62,11 +58,10 @@ public class ExperienceController {
     @Operation(summary = "경험 분해 상세정보 조회", description = "특정 경험 분해 정보를 조회합니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/experiences/{experienceId}")
-    public ApiResponse<ExperienceResult> getExperience(
+    public ApiResponse<ExperienceResult> getExperience(@AuthenticationMember Member member,
         @PathVariable(name = "experienceId") Long experienceId) {
 
-        // TODO: 추후 로그인 사용자로 수정
-        MemberInfo memberInfo = memberQueryService.getMemberInfo(1L);
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         ExperienceInfo experienceInfo = experienceQueryService.getExperience(experienceId);
 
         return ApiResponse.onSuccess(toExperienceResult(memberInfo, experienceInfo));
@@ -74,10 +69,8 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 작성", description = "경험 분해 작성 요청을 POST로 보냅니다.")
     @PostMapping("/experiences")
-    public ApiResponse<ExperienceProc> post(@RequestBody ExperienceRequest post) {
-
-        // TODO: 추후 로그인 사용자로 수정 - 1L
-        Member member = memberQueryService.findById(1L);
+    public ApiResponse<ExperienceProc> post(@AuthenticationMember Member member,
+        @RequestBody ExperienceRequest post) {
 
         return ApiResponse.onSuccess(experienceCommandService.post(post, member));
     }
@@ -103,12 +96,10 @@ public class ExperienceController {
     @Operation(summary = "경험 카드 목록 조회", description = "경험 카드 목록(Paging) 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/experience-cards")
-    public ApiResponse<ExperienceCardResult> getExperienceCards(
+    public ApiResponse<ExperienceCardResult> getExperienceCards(@AuthenticationMember Member member,
         @RequestParam(value = "page", defaultValue = "0") int page) {
 
-        // TODO: 추후 로그인 사용자로 변경 - 1L
-        Member member = memberQueryService.findById(1L);
-        MemberInfo memberInfo = memberQueryService.getMemberInfo(1L);
+        MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
 
         ExperienceCardInfo experienceCardInfo = experienceQueryService.getExperienceCardInfo(member,
             page);

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -1,17 +1,7 @@
 package com.codez4.meetfolio.domain.experience.controller;
 
-import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardResult;
-import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceResult;
-import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toRecommendCard;
-
 import com.codez4.meetfolio.domain.experience.dto.ExperienceRequest;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardItem;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardResult;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceProc;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceResult;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.RecommendCard;
+import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.*;
 import com.codez4.meetfolio.domain.experience.service.ExperienceCommandService;
 import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
 import com.codez4.meetfolio.domain.member.Member;
@@ -23,17 +13,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.*;
 
 @Tag(name = "경험 분해 API")
 @RestController

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -1,7 +1,6 @@
 package com.codez4.meetfolio.domain.experience.controller;
 
 import com.codez4.meetfolio.domain.experience.dto.ExperienceRequest;
-import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.*;
 import com.codez4.meetfolio.domain.experience.service.ExperienceCommandService;
 import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
 import com.codez4.meetfolio.domain.member.Member;

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceRequest.java
@@ -5,8 +5,9 @@ import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.global.annotation.EnumValid;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Schema(description = "경험 분해 작성 및 수정 Request")
 @Getter

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceRequest.java
@@ -3,6 +3,7 @@ package com.codez4.meetfolio.domain.experience.dto;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.annotation.EnumValid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class ExperienceRequest {
     private String motivation;
 
     @Schema(description = "맡았던 직무", example = "BACKEND")
+    @EnumValid(enumClass = JobKeyword.class)
     private String jobKeyword;
 
     @Schema(description = "사용한 기술 스택", example = "spring/mysql")

--- a/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/dto/ExperienceResponse.java
@@ -3,14 +3,15 @@ package com.codez4.meetfolio.domain.experience.dto;
 import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class ExperienceResponse {
 

--- a/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
@@ -3,10 +3,11 @@ package com.codez4.meetfolio.domain.experience.repository;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.member.Member;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
 

--- a/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/repository/ExperienceRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
 
+    void deleteByMember(Member member);
+
     Page<Experience> findAllByMember(Member member, Pageable pageable);
 
     List<Experience> findTop12ByJobKeywordOrderByIdDesc(JobKeyword jobKeyword);

--- a/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceCommandService.java
@@ -20,7 +20,6 @@ public class ExperienceCommandService {
 
     public ExperienceProc post(ExperienceRequest post, Member member) {
 
-        // TODO: 로그인 사용자로 추후 수정
         Experience experience = experienceRepository.save(ExperienceRequest.toEntity(post, member));
 
         return ExperienceResponse.toExperienceProc(experience.getId());

--- a/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/service/ExperienceQueryService.java
@@ -1,8 +1,5 @@
 package com.codez4.meetfolio.domain.experience.service;
 
-import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardInfo;
-import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceInfo;
-
 import com.codez4.meetfolio.domain.experience.Experience;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse;
 import com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
@@ -12,12 +9,16 @@ import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardInfo;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceInfo;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
@@ -2,19 +2,24 @@ package com.codez4.meetfolio.domain.feedback;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.Status;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PostUpdate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -50,4 +55,16 @@ public class Feedback extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer satisfaction;
+
+    @Column(nullable = false)
+    @ColumnDefault("'ACTIVE'")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    /**
+     * update
+     */
+    public void delete() {
+        this.status = Status.INACTIVE;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
@@ -3,22 +3,8 @@ package com.codez4.meetfolio.domain.feedback;
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.enums.Status;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.PostUpdate;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 @Getter

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/repository/FeedbackRepository.java
@@ -1,9 +1,12 @@
 package com.codez4.meetfolio.domain.feedback.repository;
 
 import com.codez4.meetfolio.domain.feedback.Feedback;
+import com.codez4.meetfolio.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     Feedback findByCoverLetterId(Long coverLetterId);
+
+    void deleteByCoverLetter_Member(Member coverLetter_member);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackCommandService.java
@@ -1,0 +1,17 @@
+package com.codez4.meetfolio.domain.feedback.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedbackCommandService {
+
+    private final FeedbackQueryService feedbackQueryService;
+
+    public void softDelete(Long coverLetterId) {
+        feedbackQueryService.findByCoverLetterId(coverLetterId).delete();
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
@@ -4,8 +4,6 @@ import com.codez4.meetfolio.domain.feedback.Feedback;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 import com.codez4.meetfolio.domain.feedback.repository.FeedbackRepository;
-import com.codez4.meetfolio.global.exception.ApiException;
-import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/service/FeedbackQueryService.java
@@ -4,6 +4,8 @@ import com.codez4.meetfolio.domain.feedback.Feedback;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse;
 import com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
 import com.codez4.meetfolio.domain.feedback.repository.FeedbackRepository;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +19,9 @@ public class FeedbackQueryService {
 
     public FeedbackInfo getFeedbackInfo(Long coverLetterId) {
 
-        Feedback feedback = feedbackRepository.findByCoverLetterId(coverLetterId);
-        return FeedbackResponse.toFeedbackInfo(feedback);
+        return FeedbackResponse.toFeedbackInfo(findByCoverLetterId(coverLetterId));
+    }
+    public Feedback findByCoverLetterId(Long coverLetterId) {
+        return feedbackRepository.findByCoverLetterId(coverLetterId);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/like/repository/LikeRepository.java
@@ -1,0 +1,9 @@
+package com.codez4.meetfolio.domain.like.repository;
+
+import com.codez4.meetfolio.domain.like.Like;
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like,Long> {
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/Member.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/Member.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @DynamicInsert
 @Getter
@@ -61,4 +62,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private JobKeyword jobKeyword;
 
+    public void setInactive(){
+        this.point = 0;
+        this.inactiveDate = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.status = Status.INACTIVE;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
@@ -38,14 +38,14 @@ public class AdminController {
         return ApiResponse.onSuccess(memberQueryService.getMemberList(page, jobKeywordEnum));
     }
 
-    @Operation(summary = "회원 삭제", description = "회원관리 메뉴에서 회원을 삭제합니다.")
+    @Operation(summary = "회원 비활성화", description = "회원관리 메뉴에서 회원을 비활성화합니다.")
     @Parameter(name = "memberId", description = "회원 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @DeleteMapping("/members-management")
     public ApiResponse<String> deleteMember(@AuthenticationMember Member admin,
                                             @PathVariable(value = "memberId") Long memberId) {
         Member member = memberQueryService.findById(memberId);
         memberCommandService.inactivateMember(member);
-        return ApiResponse.onSuccess("회원 삭제 성공입니다.");
+        return ApiResponse.onSuccess("회원 비활성화 성공입니다.");
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
@@ -1,0 +1,53 @@
+package com.codez4.meetfolio.domain.member.controller;
+
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse;
+import com.codez4.meetfolio.domain.member.service.MemberCommandService;
+import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
+import com.codez4.meetfolio.global.annotation.EnumValid;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.ApiResponse;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "관리자 API")
+@RestController
+@RequestMapping("/api/admins")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final MemberQueryService memberQueryService;
+    private final MemberCommandService memberCommandService;
+
+    @Operation(summary = "회원 목록 조회", description = "회원관리 메뉴의 회원 목록을 조회합니다.")
+    @GetMapping("/members-management")
+    public ApiResponse<MemberResponse.MemberListResult> getMemberList(@AuthenticationMember Member admin,
+                                                                      @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                      @RequestParam(value = "jobKeyword", required = false) String jobKeyword){
+        JobKeyword jobKeywordEnum;
+        if(jobKeyword!=null) {
+            jobKeywordEnum = JobKeyword.convert(jobKeyword);
+            if(jobKeywordEnum==null) throw new ApiException(ErrorStatus._BAD_REQUEST);
+        }
+        else jobKeywordEnum = null;
+        return ApiResponse.onSuccess(memberQueryService.getMemberList(admin,page, jobKeywordEnum));
+    }
+
+    @Operation(summary = "회원 삭제", description = "회원관리 메뉴에서 회원을 삭제합니다.")
+    @Parameter(name = "memberId", description = "회원 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @DeleteMapping("/members-management")
+    public ApiResponse<String> deleteMember(@AuthenticationMember Member admin,
+                                            @PathVariable(value = "memberId") Long memberId){
+        Member member = memberQueryService.findById(memberId);
+        memberCommandService.inactiveMember(member);
+        return ApiResponse.onSuccess("회원 삭제 성공입니다.");
+    }
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
@@ -46,7 +46,7 @@ public class AdminController {
     public ApiResponse<String> deleteMember(@AuthenticationMember Member admin,
                                             @PathVariable(value = "memberId") Long memberId){
         Member member = memberQueryService.findById(memberId);
-        memberCommandService.inactiveMember(member);
+        memberCommandService.inactivateMember(member);
         return ApiResponse.onSuccess("회원 삭제 성공입니다.");
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AdminController.java
@@ -6,7 +6,6 @@ import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.service.MemberCommandService;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
-import com.codez4.meetfolio.global.annotation.EnumValid;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
@@ -28,23 +27,22 @@ public class AdminController {
 
     @Operation(summary = "회원 목록 조회", description = "회원관리 메뉴의 회원 목록을 조회합니다.")
     @GetMapping("/members-management")
-    public ApiResponse<MemberResponse.MemberListResult> getMemberList(@AuthenticationMember Member admin,
-                                                                      @RequestParam(value = "page", defaultValue = "0") int page,
-                                                                      @RequestParam(value = "jobKeyword", required = false) String jobKeyword){
+    public ApiResponse<MemberResponse.MemberList> getMemberList(@AuthenticationMember Member admin,
+                                                                @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                @RequestParam(value = "jobKeyword", required = false) String jobKeyword) {
         JobKeyword jobKeywordEnum;
-        if(jobKeyword!=null) {
+        if (jobKeyword != null) {
             jobKeywordEnum = JobKeyword.convert(jobKeyword);
-            if(jobKeywordEnum==null) throw new ApiException(ErrorStatus._BAD_REQUEST);
-        }
-        else jobKeywordEnum = null;
-        return ApiResponse.onSuccess(memberQueryService.getMemberList(admin,page, jobKeywordEnum));
+            if (jobKeywordEnum == null) throw new ApiException(ErrorStatus._BAD_REQUEST);
+        } else jobKeywordEnum = null;
+        return ApiResponse.onSuccess(memberQueryService.getMemberList(page, jobKeywordEnum));
     }
 
     @Operation(summary = "회원 삭제", description = "회원관리 메뉴에서 회원을 삭제합니다.")
     @Parameter(name = "memberId", description = "회원 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @DeleteMapping("/members-management")
     public ApiResponse<String> deleteMember(@AuthenticationMember Member admin,
-                                            @PathVariable(value = "memberId") Long memberId){
+                                            @PathVariable(value = "memberId") Long memberId) {
         Member member = memberQueryService.findById(memberId);
         memberCommandService.inactivateMember(member);
         return ApiResponse.onSuccess("회원 삭제 성공입니다.");

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.codez4.meetfolio.domain.member.controller;
+
+import com.codez4.meetfolio.domain.member.dto.LoginRequest;
+import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.global.jwt.JwtProperties;
+import com.codez4.meetfolio.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "로그인/로그아웃 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberQueryService memberQueryService;
+
+    @Operation(summary = "로그인", description = "로그인")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<String>> login(@Valid @RequestBody LoginRequest request){
+        String jwtToken = memberQueryService.login(request);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(JwtProperties.HEADER_STRING,JwtProperties.TOKEN_PREFIX + jwtToken);
+        return ResponseEntity.ok().headers(headers).body(ApiResponse.onSuccess("로그인에 성공하였습니다."));
+    }
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
@@ -3,42 +3,25 @@ package com.codez4.meetfolio.domain.member.controller;
 import com.codez4.meetfolio.domain.enums.Grade;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.Major;
-import com.codez4.meetfolio.domain.member.Member;
-import com.codez4.meetfolio.domain.member.dto.LoginRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.service.MemberCommandService;
-import com.codez4.meetfolio.domain.member.service.MemberQueryService;
-import com.codez4.meetfolio.global.annotation.AuthenticationMember;
-import com.codez4.meetfolio.global.jwt.JwtProperties;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import com.codez4.meetfolio.domain.member.dto.MemberRequest;
-import com.codez4.meetfolio.domain.member.dto.MemberResponse;
-import com.codez4.meetfolio.domain.member.service.MemberCommandService;
-import com.codez4.meetfolio.global.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "회원 API")
+@Tag(name = "사용자 API")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
 
     @Operation(summary = "회원 가입", description = "회원 가입")
@@ -52,15 +35,6 @@ public class MemberController {
                 .major(Major.convert(request.getMajor()))
                 .build();
         return ApiResponse.onSuccess(memberCommandService.post(post));
-    }
-
-    @Operation(summary = "로그인", description = "로그인")
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<String>> login(@Valid @RequestBody LoginRequest request){
-        String jwtToken = memberQueryService.login(request);
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(JwtProperties.HEADER_STRING,JwtProperties.TOKEN_PREFIX + jwtToken);
-        return ResponseEntity.ok().headers(headers).body(ApiResponse.onSuccess("로그인에 성공하였습니다."));
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public class MemberResponse {
 
-    @Schema(description = "사용자 정보 응답 DTO")
+    @Schema(description = "로그인 사용자 정보 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
@@ -44,7 +44,7 @@ public class MemberResponse {
         private LocalDateTime createdAt;
     }
 
-    @Schema(description = "회원 목록 응답 DTO")
+    @Schema(description = "회원 관리 - 회원 목록 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
@@ -56,6 +56,7 @@ public class MemberResponse {
         private MemberList memberList;
     }
 
+    @Schema(description = "회원 목록 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -1,13 +1,17 @@
 package com.codez4.meetfolio.domain.member.dto;
 
 import com.codez4.meetfolio.domain.member.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberResponse {
 
@@ -40,14 +44,109 @@ public class MemberResponse {
         private LocalDateTime createdAt;
     }
 
+    @Schema(description = "회원 목록 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MemberListResult {
+        @Schema(description = "로그인 사용자 정보")
+        private MemberInfo memberInfo;
+        @Schema(description = "회원 목록")
+        private MemberList memberList;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MemberList {
+
+        @Schema(description = "회원 목록")
+        private List<MemberResponse.MemberDetailInfo> memberList;
+
+        @Schema(description = "페이징된 리스트의 항목 개수")
+        private Integer listSize;
+
+        @Schema(description = "총 페이징 수 ")
+        private Integer totalPage;
+
+        @Schema(description = "전체 데이터의 개수")
+        private Long totalElements;
+
+        @Schema(description = "첫 페이지의 여부")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지의 여부")
+        private Boolean isLast;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MemberDetailInfo {
+
+        @Schema(description = "사용자 고유 번호")
+        private Long memberId;
+        @Schema(description = "회원 가입일")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate registrationDate;
+        @Schema(description = "사용자 이메일")
+        private String email;
+        @Schema(description = "사용자 학년 및 학적")
+        private String grade;
+        @Schema(description = "사용자 학과")
+        private String major;
+        @Schema(description = "희망 직무")
+        private String jobKeyword;
+        @Schema(description = "포인트")
+        private int point;
+    }
+
+
     public static MemberInfo toMemberInfo(Member member) {
+        return member == null ? null :
+                MemberInfo.builder()
+                        .memberName(member.getEmail())
+                        .profile(member.getProfile())
+                        .major(member.getMajor().name())
+                        .build();
+    }
+
+    public static MemberListResult toMemberListResult(Member member, Page<Member> members){
+        return MemberListResult.builder()
+                .memberInfo(toMemberInfo(member))
+                .memberList(toMemberList(members))
+                .build();
+    }
+    public static MemberList toMemberList(Page<Member> members){
+        List<MemberDetailInfo> memberList = members.stream()
+                .map(MemberResponse::toMemberDetailInfo)
+                .toList();
+        return MemberList.builder()
+                .memberList(memberList)
+                .listSize(memberList.size())
+                .totalPage(members.getTotalPages())
+                .totalElements(members.getTotalElements())
+                .isFirst(members.isFirst())
+                .isLast(members.isLast())
+                .build();
+
+    }
+
+    public static MemberDetailInfo toMemberDetailInfo(Member member) {
 
         return member == null ? null :
-            MemberInfo.builder()
-                .memberName(member.getEmail())
-                .profile(member.getProfile())
-                .major(member.getMajor().name())
-                .build();
+                MemberDetailInfo.builder()
+                        .memberId(member.getId())
+                        .registrationDate(member.getCreatedAt().toLocalDate())
+                        .email(member.getEmail())
+                        .grade(member.getGrade().getDescription())
+                        .major(member.getMajor().getDescription())
+                        .jobKeyword(member.getJobKeyword().getDescription())
+                        .point(member.getPoint())
+                        .build();
     }
 
     public static MemberProc toMemberProc(Member member) {

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -49,18 +49,6 @@ public class MemberResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class MemberListResult {
-        @Schema(description = "로그인 사용자 정보")
-        private MemberInfo memberInfo;
-        @Schema(description = "회원 목록")
-        private MemberList memberList;
-    }
-
-    @Schema(description = "회원 목록 DTO")
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Getter
     public static class MemberList {
 
         @Schema(description = "회원 목록")
@@ -115,13 +103,7 @@ public class MemberResponse {
                         .build();
     }
 
-    public static MemberListResult toMemberListResult(Member member, Page<Member> members){
-        return MemberListResult.builder()
-                .memberInfo(toMemberInfo(member))
-                .memberList(toMemberList(members))
-                .build();
-    }
-    public static MemberList toMemberList(Page<Member> members){
+    public static MemberList toMemberList(Page<Member> members) {
         List<MemberDetailInfo> memberList = members.stream()
                 .map(MemberResponse::toMemberDetailInfo)
                 .toList();

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -108,9 +108,9 @@ public class MemberResponse {
     public static MemberInfo toMemberInfo(Member member) {
         return member == null ? null :
                 MemberInfo.builder()
-                        .memberName(member.getEmail())
+                        .memberName(member.getEmail().split("@")[0])
                         .profile(member.getProfile())
-                        .major(member.getMajor().name())
+                        .major(member.getMajor().getDescription())
                         .build();
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/repository/MemberRepository.java
@@ -1,6 +1,11 @@
 package com.codez4.meetfolio.domain.member.repository;
 
+import com.codez4.meetfolio.domain.enums.Authority;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +13,9 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    Page<Member> findMemberByStatusAndAuthority(Status status, Authority authority, Pageable pageable);
+
+    Page<Member> findMemberByStatusAndAuthorityAndJobKeyword(Status status, Authority authority, JobKeyword jobKeyword, Pageable pageable);
+
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
@@ -33,7 +33,7 @@ public class MemberCommandService {
         return MemberResponse.toMemberProc(member);
     }
 
-    public void inactiveMember(Member member) {
+    public void inactivateMember(Member member) {
         // 자식 댓글 삭제
         commentRepository.deleteByParentComment_Member(member);
         // 부모 댓글 삭제

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
@@ -2,9 +2,10 @@ package com.codez4.meetfolio.domain.member.service;
 
 import com.codez4.meetfolio.domain.board.repository.BoardRepository;
 import com.codez4.meetfolio.domain.comment.repository.CommentRepository;
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
 import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
-import com.codez4.meetfolio.domain.feedback.repository.FeedbackRepository;
+import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
@@ -21,7 +22,7 @@ public class MemberCommandService {
     private final ExperienceRepository experienceRepository;
     private final CoverLetterRepository coverLetterRepository;
     private final BoardRepository boardRepository;
-    private final FeedbackRepository feedbackRepository;
+    private final LikeRepository likeRepository;
     private final CommentRepository commentRepository;
 
     public Member save(MemberRequest.Post post) {
@@ -34,10 +35,11 @@ public class MemberCommandService {
     }
 
     public void inactivateMember(Member member) {
-        commentRepository.deleteByParentComment_Member(member);
         commentRepository.deleteByMember(member);
+        likeRepository.deleteByMember(member);
         boardRepository.deleteByMember(member);
         experienceRepository.deleteByMember(member);
+        coverLetterRepository.findByMember(member).forEach(CoverLetter::delete);
         member.setInactive();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
@@ -1,5 +1,10 @@
 package com.codez4.meetfolio.domain.member.service;
 
+import com.codez4.meetfolio.domain.board.repository.BoardRepository;
+import com.codez4.meetfolio.domain.comment.repository.CommentRepository;
+import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
+import com.codez4.meetfolio.domain.feedback.repository.FeedbackRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
@@ -13,6 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MemberCommandService {
     private final MemberRepository memberRepository;
+    private final ExperienceRepository experienceRepository;
+    private final CoverLetterRepository coverLetterRepository;
+    private final BoardRepository boardRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final CommentRepository commentRepository;
 
     public Member save(MemberRequest.Post post) {
         return memberRepository.save(MemberRequest.toEntity(post));
@@ -21,5 +31,20 @@ public class MemberCommandService {
     public MemberResponse.MemberProc post(MemberRequest.Post post) {
         Member member = save(post);
         return MemberResponse.toMemberProc(member);
+    }
+
+    public void inactiveMember(Member member) {
+        // 자식 댓글 삭제
+        commentRepository.deleteByParentComment_Member(member);
+        // 부모 댓글 삭제
+        commentRepository.deleteByMember(member);
+        // 게시물 삭제
+        boardRepository.deleteByMember(member);
+        // 경험 분해 삭제
+        experienceRepository.deleteByMember(member);
+        // 자소서 삭제
+        coverLetterRepository.deleteByMember(member);
+        // 회원 비활성화
+        member.setInactive();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
@@ -34,17 +34,10 @@ public class MemberCommandService {
     }
 
     public void inactivateMember(Member member) {
-        // 자식 댓글 삭제
         commentRepository.deleteByParentComment_Member(member);
-        // 부모 댓글 삭제
         commentRepository.deleteByMember(member);
-        // 게시물 삭제
         boardRepository.deleteByMember(member);
-        // 경험 분해 삭제
         experienceRepository.deleteByMember(member);
-        // 자소서 삭제
-        coverLetterRepository.deleteByMember(member);
-        // 회원 비활성화
         member.setInactive();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
-import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberListResult;
+import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberList;
 import static com.codez4.meetfolio.global.security.Password.ENCODER;
 
 @Service
@@ -61,12 +61,12 @@ public class MemberQueryService {
         }
     }
 
-    public MemberResponse.MemberListResult getMemberList(Member member, int page, JobKeyword jobKeyword) {
+    public MemberResponse.MemberList getMemberList(int page, JobKeyword jobKeyword) {
         PageRequest pageRequest = PageRequest.of(page, 12, Sort.by("createdAt").descending());
         if (jobKeyword == null) {
-            return toMemberListResult(member, memberRepository.findMemberByStatusAndAuthority(Status.ACTIVE, Authority.MEMBER, pageRequest));
+            return toMemberList(memberRepository.findMemberByStatusAndAuthority(Status.ACTIVE, Authority.MEMBER, pageRequest));
         } else
-            return toMemberListResult(member, memberRepository.findMemberByStatusAndAuthorityAndJobKeyword(Status.ACTIVE, Authority.MEMBER, jobKeyword, pageRequest));
+            return toMemberList(memberRepository.findMemberByStatusAndAuthorityAndJobKeyword(Status.ACTIVE, Authority.MEMBER, jobKeyword, pageRequest));
     }
 
     private void comparePassword(String password, Password savedPassword) {

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -1,20 +1,18 @@
 package com.codez4.meetfolio.domain.member.service;
 
+import static com.codez4.meetfolio.global.security.Password.ENCODER;
+
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.LoginRequest;
-import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import com.codez4.meetfolio.domain.member.repository.MemberRepository;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.codez4.meetfolio.global.security.Password;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Optional;
-
-import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
-import static com.codez4.meetfolio.global.security.Password.ENCODER;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +24,7 @@ public class MemberQueryService {
 
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(
-                () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
         );
     }
 
@@ -35,14 +33,12 @@ public class MemberQueryService {
         return member;
     }
 
-    public MemberInfo getMemberInfo(Long memberId) {
-        return toMemberInfo(findById(memberId));
-    }
-
     public String login(LoginRequest request) {
-        Member member = findByEmail(request.getEmail()).orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
+        Member member = findByEmail(request.getEmail()).orElseThrow(
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
         comparePassword(request.getPassword(), member.getPassword());
-        String token = jwtTokenProvider.generate(member.getEmail(), member.getId(), member.getAuthority());
+        String token = jwtTokenProvider.generate(member.getEmail(), member.getId(),
+            member.getAuthority());
         return token;
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/payment/Payment.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/Payment.java
@@ -1,7 +1,7 @@
 package com.codez4.meetfolio.domain.payment;
 
-import com.codez4.meetfolio.domain.point.Point;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.point.Point;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
+++ b/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     private final JwtExceptionFilter jwtExceptionFilter;
     private static final String[] WHITE_LIST_URL = {
             // application
+            "/api",
             "/api/login",
             "/api/signup",
             "/api/signup/email",

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtAuthenticationFilter.java
@@ -38,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || request.getServletPath().contains("/swagger-ui")
                 || request.getServletPath().contains("/swagger-resources")
                 || request.getServletPath().contains("v3/api-docs")
+                || request.getServletPath().equals("/api")
         ) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
@@ -50,7 +50,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setSubject(email)
                 .claim(USER_ID_KEY, userId)
-                .claim(AUTHORITIES_KEY, authority)
+                .claim(AUTHORITIES_KEY, authority.getDescription())
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
                 .setExpiration(expiredAt)
                 .signWith(key, SignatureAlgorithm.HS512)

--- a/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/codez4/meetfolio/global/response/code/status/ErrorStatus.java
@@ -40,7 +40,16 @@ public enum ErrorStatus implements BaseErrorCode {
     // ================================================================================================================= //
 
     // 자기소개서 관련
-    _COVERLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "COVERLETTER4001", "존재하지 않는 자기소개서 데이터입니다.");
+    _COVERLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "COVERLETTER4001", "존재하지 않는 자기소개서 데이터입니다."),
+
+    // ================================================================================================================= //
+
+    // AI 피드백 관련
+    _FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "FEEDBACK4001", "존재하지 않는 피드백 데이터입니다."),
+    // ================================================================================================================= //
+
+    // AI 직무 역량 분석 관련
+    _ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS4001", "존재하지 않는 AI 직무 역량 분석 데이터입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/codez4/meetfolio/global/security/CustomUserDetails.java
+++ b/src/main/java/com/codez4/meetfolio/global/security/CustomUserDetails.java
@@ -17,7 +17,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority(member.getAuthority().toString()));
+        authorities.add(new SimpleGrantedAuthority(member.getAuthority().getDescription()));
         return authorities;
     }
 


### PR DESCRIPTION
## 요약

- 관리자 회원 관리  - 회원 목록 조회 API 구현
- 관리자 회원 관리  - 회원 삭제 API 구현
- 로그인 API MemberController-> AuthController 이동

## 상세 내용

- 로그인 API MemberController-> AuthController 이동
- security 관리자 인가 로직 수정
  - Security에서 권한에 따른 서비스 인가할 때, "ROLE_MEMBER" 또는 "ROLE_ADMIN"와 같이 "ROLE_"로 Authority가 시작하여야함
  - 이에 따른 Authority enum class 수정
- 관리자 회원 관리  - 회원 목록 조회 API 구현
- 관리자 회원 관리  - 회원 삭제 API 구현
- 로그인 사용자 정보 조회 로직 수정

## 질문 및 이외 사항
@kylo-dev 
- AdminController 
  - 회원 목록 조회 API에서 parameter로 jobKeyword를 받는데(required=false),`@EnumValid`를 사용하려 하였으나 필터링을 안 할 경우 null 값이 들어와 에러 발생
  - 따라서 null 값 들어오면 전체 조회, 값이 있을 시에 enum 검증하는 로직 추가
  - 이 부분 이렇게 하는게 맞을지,,, 코드좀 봐주세영
 
- MembeCommandService - inactiveMember
  - 먼저 pr 올려주신 자소서 정책에 대한 확정이 덜 되어 자소서 삭제 로직은 구현이 안 된 상태입니다.
  - 논의 후 반영하여 커밋 올리겠습니다.

## 이슈 번호

- close #23 
