### PR TITLE
Refactor: 게시물 목록 Page 타입에서 Slice타입으로 변환

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
@@ -29,7 +29,7 @@ public class BoardController {
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "category", description = "직무 키워드, Query String입니다. BACKEND/WEB/APP/DESIGN/AI", example = "BACKEND", in = ParameterIn.QUERY)
     @GetMapping("/boards/employment")
-    public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getJobBoardList(@AuthenticationMember Member member,
+    public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getEmploymentBoards(@AuthenticationMember Member member,
                                                                                @RequestParam(name = "page") Integer page,
                                                                                @RequestParam(name = "category", required = false) String category) {
         if (category != null) {

--- a/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
@@ -28,7 +28,7 @@ public class BoardController {
     @Operation(summary = "취업 정보 게시판 조회", description = "커뮤니티 메뉴에서 취업 정보 게시판을 조회합니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "category", description = "직무 키워드, Query String입니다. BACKEND/WEB/APP/DESIGN/AI", example = "BACKEND", in = ParameterIn.QUERY)
-    @GetMapping("/boards")
+    @GetMapping("/boards/employment")
     public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getJobBoardList(@AuthenticationMember Member member,
                                                                                @RequestParam(name = "page") Integer page,
                                                                                @RequestParam(name = "category", required = false) String category) {

--- a/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
@@ -1,15 +1,41 @@
 package com.codez4.meetfolio.domain.board.controller;
 
+import com.codez4.meetfolio.domain.board.dto.BoardResponse;
+import com.codez4.meetfolio.domain.board.service.BoardQueryService;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
+import com.codez4.meetfolio.global.response.ApiResponse;
+import com.codez4.meetfolio.global.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "커뮤니티 게시글 API")
+@Tag(name = "커뮤니티 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class BoardController {
 
+    private final BoardQueryService boardQueryService;
+
+    @Operation(summary = "취업 정보 게시판 조회", description = "커뮤니티 메뉴에서 취업 정보 게시판을 조회합니다.")
+    @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
+    @Parameter(name = "category", description = "직무 키워드, Query String입니다. BACKEND/WEB/APP/DESIGN/AI", example = "BACKEND", in = ParameterIn.QUERY)
+    @GetMapping("/boards")
+    public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getJobBoardList(@AuthenticationMember Member member,
+                                                                               @RequestParam(name = "page") Integer page,
+                                                                               @RequestParam(name = "category", required = false) String category) {
+        if (category != null) {
+            JobKeyword jobKeyword = JobKeyword.convert(category);
+            return ApiResponse.onSuccess(boardQueryService.getEmploymentBoardsByJobKeyword(member, page, jobKeyword));
+        } else return ApiResponse.onSuccess(boardQueryService.getEmploymentBoards(member, page));
+    }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.codez4.meetfolio.domain.board.controller;
 
 import com.codez4.meetfolio.domain.board.dto.BoardResponse;
 import com.codez4.meetfolio.domain.board.service.BoardQueryService;
+import com.codez4.meetfolio.domain.enums.GroupCategory;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
@@ -36,6 +37,19 @@ public class BoardController {
             JobKeyword jobKeyword = JobKeyword.convert(category);
             return ApiResponse.onSuccess(boardQueryService.getEmploymentBoardsByJobKeyword(member, page, jobKeyword));
         } else return ApiResponse.onSuccess(boardQueryService.getEmploymentBoards(member, page));
+    }
+
+    @Operation(summary = "그룹원 모집 게시판 조회", description = "커뮤니티 메뉴에서 그룹원 모집 게시판을 조회합니다.")
+    @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
+    @Parameter(name = "category", description = "그룹 카테고리, Query String입니다. STUDY/CONTEST", example = "STUDY", in = ParameterIn.QUERY)
+    @GetMapping("/boards/group")
+    public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getJobBoardList(@AuthenticationMember Member member,
+                                                                               @RequestParam(name = "page") Integer page,
+                                                                               @RequestParam(name = "category", required = false) String category) {
+        if (category != null) {
+            GroupCategory groupCategory = GroupCategory.convert(category);
+            return ApiResponse.onSuccess(boardQueryService.getGroupBoardsByGroupCategory(member, page, groupCategory));
+        } else return ApiResponse.onSuccess(boardQueryService.getGroupBoards(member, page));
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.codez4.meetfolio.domain.board.service.BoardQueryService;
 import com.codez4.meetfolio.domain.enums.GroupCategory;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import com.codez4.meetfolio.global.response.SliceResponse;
@@ -18,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.codez4.meetfolio.domain.board.dto.BoardResponse.toBoardResult;
+
 @Tag(name = "커뮤니티 API")
 @RestController
 @RequiredArgsConstructor
@@ -30,26 +33,28 @@ public class BoardController {
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "category", description = "직무 키워드, Query String입니다. BACKEND/WEB/APP/DESIGN/AI", example = "BACKEND", in = ParameterIn.QUERY)
     @GetMapping("/boards/employment")
-    public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getEmploymentBoards(@AuthenticationMember Member member,
-                                                                               @RequestParam(name = "page") Integer page,
-                                                                               @RequestParam(name = "category", required = false) String category) {
+    public ApiResponse<BoardResponse.BoardResult> getEmploymentBoards(@AuthenticationMember Member member,
+                                                                      @RequestParam(name = "page") Integer page,
+                                                                      @RequestParam(name = "category", required = false) String category) {
+        MemberResponse.MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         if (category != null) {
             JobKeyword jobKeyword = JobKeyword.convert(category);
-            return ApiResponse.onSuccess(boardQueryService.getEmploymentBoardsByJobKeyword(member, page, jobKeyword));
-        } else return ApiResponse.onSuccess(boardQueryService.getEmploymentBoards(member, page));
+            return ApiResponse.onSuccess(toBoardResult(memberInfo,boardQueryService.getEmploymentBoardsByJobKeyword(member, page, jobKeyword)));
+        } else return ApiResponse.onSuccess(toBoardResult(memberInfo,boardQueryService.getEmploymentBoards(member, page)));
     }
 
     @Operation(summary = "그룹원 모집 게시판 조회", description = "커뮤니티 메뉴에서 그룹원 모집 게시판을 조회합니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "category", description = "그룹 카테고리, Query String입니다. STUDY/CONTEST", example = "STUDY", in = ParameterIn.QUERY)
     @GetMapping("/boards/group")
-    public ApiResponse<SliceResponse<BoardResponse.BoardItem>> getJobBoardList(@AuthenticationMember Member member,
+    public ApiResponse<BoardResponse.BoardResult> getJobBoardList(@AuthenticationMember Member member,
                                                                                @RequestParam(name = "page") Integer page,
                                                                                @RequestParam(name = "category", required = false) String category) {
+        MemberResponse.MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         if (category != null) {
             GroupCategory groupCategory = GroupCategory.convert(category);
-            return ApiResponse.onSuccess(boardQueryService.getGroupBoardsByGroupCategory(member, page, groupCategory));
-        } else return ApiResponse.onSuccess(boardQueryService.getGroupBoards(member, page));
+            return ApiResponse.onSuccess(toBoardResult(memberInfo, boardQueryService.getGroupBoardsByGroupCategory(member, page, groupCategory)));
+        } else return ApiResponse.onSuccess(toBoardResult(memberInfo,boardQueryService.getGroupBoards(member, page)));
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/dto/BoardQueryItem.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/dto/BoardQueryItem.java
@@ -1,0 +1,76 @@
+package com.codez4.meetfolio.domain.board.dto;
+
+import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.board.EmploymentBoard;
+import com.codez4.meetfolio.domain.board.GroupBoard;
+import com.codez4.meetfolio.domain.enums.GroupCategory;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.enums.Status;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardQueryItem {
+
+    private Long id;
+
+    private String email;
+
+    private String title;
+
+    private String content;
+
+    private Integer likeCount;
+
+    private Status status;
+
+    private Integer commentCount;
+
+    private JobKeyword jobKeyword;
+
+    private GroupCategory groupCategory;
+
+    private String recruitment;
+
+    private Integer peopleNumber;
+
+    private LocalDateTime createdAt;
+
+    public BoardQueryItem(Board board, String email, Status status) {
+        if (board instanceof EmploymentBoard employmentBoard){
+            this.id = employmentBoard.getId();
+            this.email = email;
+            this.title = employmentBoard.getTitle();
+            this.content = employmentBoard.getContent();
+            this.likeCount = employmentBoard.getLikeCount();
+            this.status = status == null ? Status.INACTIVE : status ;
+            this.commentCount = employmentBoard.getCommentCount();
+            this.jobKeyword = employmentBoard.getJobKeyword();
+            this.createdAt = employmentBoard.getCreatedAt();
+            this.groupCategory = null;
+            this.peopleNumber = null;
+            this.recruitment = null;
+        }
+        else if (board instanceof GroupBoard groupBoard){
+            this.id = groupBoard.getId();
+            this.email = email;
+            this.title = groupBoard.getTitle();
+            this.content = groupBoard.getContent();
+            this.likeCount = groupBoard.getLikeCount();
+            this.status = status == null ? Status.INACTIVE : Status.ACTIVE ;
+            this.commentCount = board.getCommentCount();
+            this.jobKeyword = null;
+            this.createdAt = groupBoard.getCreatedAt();
+            this.groupCategory = groupBoard.getGroupCategory();
+            this.peopleNumber = groupBoard.getPeopleNumber();
+            this.recruitment = groupBoard.getRecruitment();
+        }
+
+    }
+
+}

--- a/src/main/java/com/codez4/meetfolio/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/dto/BoardResponse.java
@@ -31,40 +31,10 @@ public class BoardResponse {
     public static BoardResult toBoardResult(MemberInfo memberInfo, SliceResponse<BoardItem> boardInfo) {
 
         return BoardResult.builder()
-            .memberInfo(memberInfo)
-            .boardInfo(boardInfo)
-            .build();
+                .memberInfo(memberInfo)
+                .boardInfo(boardInfo)
+                .build();
     }
-//
-//    public static <T> S toBoardInfo(Slice<T> slice, List<Status> statusList) {
-//        List<BoardItem> boardItems;
-//        List<Board> boards;
-//
-//        boards = slice.getContent().stream()
-//            .map(item -> {
-//                if (item instanceof Board) {
-//                    return (Board) item;
-//                } else if (item instanceof Like) {
-//                    return ((Like) item).getBoard();
-//                } else {
-//                    throw new ApiException(ErrorStatus._BAD_REQUEST);
-//                }
-//            })
-//            .toList();
-//
-//        boardItems = IntStream.range(0, boards.size())
-//            .mapToObj(i -> toBoardItem(boards.get(i), statusList.get(i)))
-//            .toList();
-//
-//        return BoardInfo.builder()
-//            .boardItems(boardItems)
-//            .listSize(boardItems.size())
-//            .totalPage(page.getTotalPages())
-//            .totalElements(page.getTotalElements())
-//            .isFirst(page.isFirst())
-//            .isLast(page.isLast())
-//            .build();
-//    }
 
     @Schema(description = "커뮤니티 게시글 응답 DTO")
     @Builder
@@ -124,6 +94,7 @@ public class BoardResponse {
         }
 
     }
+
     public static BoardItem toBoardItem(BoardQueryItem board) {
         BoardItemBuilder boardItemBuilder = BoardItem.builder()
                 .memberName(board.getEmail().split("@")[0])
@@ -137,8 +108,7 @@ public class BoardResponse {
 
         if (board.getJobKeyword() != null) {
             boardItemBuilder
-                    .jobCategory(board.getJobKeyword().getDescription())
-                    .build();
+                    .jobCategory(board.getJobKeyword().getDescription());
         } else if (board.getGroupCategory() != null) {
             boardItemBuilder
                     .groupCategory(board.getGroupCategory().getDescription())

--- a/src/main/java/com/codez4/meetfolio/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/dto/BoardResponse.java
@@ -22,15 +22,15 @@ public class BoardResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class MyBoardResult {
+    public static class BoardResult {
 
         private MemberResponse.MemberInfo memberInfo;
         private SliceResponse<BoardItem> boardInfo;
     }
 
-    public static MyBoardResult toMyBoardResult(MemberInfo memberInfo, SliceResponse<BoardItem> boardInfo) {
+    public static BoardResult toBoardResult(MemberInfo memberInfo, SliceResponse<BoardItem> boardInfo) {
 
-        return MyBoardResult.builder()
+        return BoardResult.builder()
             .memberInfo(memberInfo)
             .boardInfo(boardInfo)
             .build();

--- a/src/main/java/com/codez4/meetfolio/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/repository/BoardRepository.java
@@ -1,14 +1,21 @@
 package com.codez4.meetfolio.domain.board.repository;
 
 import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.member.Member;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     void deleteByMember(Member member);
 
-    Page<Board> findAllByMember(Member member, PageRequest pageRequest);
+    Slice<Board> findAllByMember(Member member, PageRequest pageRequest);
+
+    @Query(value = "SELECT " +
+            "NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(b, b.member.email, (SELECT l.status from Like l WHERE l.member = :member AND l.board = b)) FROM Board b WHERE b.member = :member")
+    Slice<BoardQueryItem> queryFindAllMyBoards(Member member, Pageable pageable);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/repository/EmploymentBoardRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/repository/EmploymentBoardRepository.java
@@ -1,0 +1,23 @@
+package com.codez4.meetfolio.domain.board.repository;
+
+import com.codez4.meetfolio.domain.board.EmploymentBoard;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface EmploymentBoardRepository extends JpaRepository<EmploymentBoard, Long> {
+
+    Slice<EmploymentBoard> findSliceBy(Pageable pageable);
+
+    @Query("SELECT " +
+            "NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(eb, eb.member.email,(SELECT l.status FROM Like l WHERE l.member = :member AND eb = l.board)) FROM EmploymentBoard eb")
+    Slice<BoardQueryItem> queryFindAllEmploymentBoards(Member member, Pageable pageable);
+
+    @Query("SELECT " +
+            "NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(eb, eb.member.email, (SELECT l.status FROM Like l WHERE l.member = :member AND eb = l.board)) FROM EmploymentBoard eb WHERE eb.jobKeyword = :jobKeyword ")
+    Slice<BoardQueryItem> queryFindAllEmploymentBoardsByJobKeyword(Member member, JobKeyword jobKeyword, Pageable pageable);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/board/repository/GroupBoardRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/repository/GroupBoardRepository.java
@@ -1,0 +1,21 @@
+package com.codez4.meetfolio.domain.board.repository;
+
+import com.codez4.meetfolio.domain.board.GroupBoard;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
+import com.codez4.meetfolio.domain.enums.GroupCategory;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.member.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface GroupBoardRepository extends JpaRepository<GroupBoard, Long> {
+    @Query("SELECT " +
+            "NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(gb, gb.member.email,(SELECT l.status FROM Like l WHERE l.member = :member AND gb = l.board)) FROM GroupBoard gb")
+    Slice<BoardQueryItem> queryFindAllGroupBoards(Member member, Pageable pageable);
+
+    @Query("SELECT " +
+            "NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(gb, gb.member.email, (SELECT l.status FROM Like l WHERE l.member = :member AND gb = l.board)) FROM GroupBoard gb WHERE gb.groupCategory = :groupCategory ")
+    Slice<BoardQueryItem> queryFindAllGroupBoardsByGroupCategory(Member member, GroupCategory groupCategory, Pageable pageable);
+}

--- a/src/main/java/com/codez4/meetfolio/domain/board/service/BoardQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/service/BoardQueryService.java
@@ -1,20 +1,20 @@
 package com.codez4.meetfolio.domain.board.service;
 
-import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.board.dto.BoardResponse;
-import com.codez4.meetfolio.domain.board.dto.BoardResponse.BoardInfo;
 import com.codez4.meetfolio.domain.board.repository.BoardRepository;
-import com.codez4.meetfolio.domain.enums.Status;
-import com.codez4.meetfolio.domain.like.service.LikeQueryService;
+import com.codez4.meetfolio.domain.board.repository.EmploymentBoardRepository;
+import com.codez4.meetfolio.domain.enums.JobKeyword;
+import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,16 +22,28 @@ import java.util.List;
 public class BoardQueryService {
 
     private final BoardRepository boardRepository;
-    private final LikeQueryService likeQueryService;
+    private final EmploymentBoardRepository employmentBoardRepository;
 
-    // 내가 작성한 게시글 목록
-    public BoardInfo findMyBoards(Member member, Integer page) {
+    public SliceResponse<BoardResponse.BoardItem> getEmploymentBoards(Member member, int page) {
+        Pageable pageable = PageRequest.of(page, 6, Sort.by("id").descending());
+        Slice<BoardQueryItem> employmentBoards =
+                employmentBoardRepository.queryFindAllEmploymentBoards(member, pageable);
+        Slice<BoardResponse.BoardItem> boards = employmentBoards.map(BoardResponse::toBoardItem);
+        return new SliceResponse<>(boards);
+    }
 
+    public SliceResponse<BoardResponse.BoardItem> getEmploymentBoardsByJobKeyword(Member member, int page, JobKeyword jobKeyword) {
+        Pageable pageable = PageRequest.of(page, 6, Sort.by("id").descending());
+        Slice<BoardQueryItem> employmentBoards =
+                employmentBoardRepository.queryFindAllEmploymentBoardsByJobKeyword(member, jobKeyword,pageable);
+        Slice<BoardResponse.BoardItem> boards = employmentBoards.map(BoardResponse::toBoardItem);
+        return new SliceResponse<>(boards);
+    }
+
+    public SliceResponse<BoardResponse.BoardItem> findMyBoards(Member member, Integer page) {
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("id").descending());
-
-        Page<Board> myBoards = boardRepository.findAllByMember(member, pageRequest);
-        List<Status> likeStatus = likeQueryService.getLikeStatus(member, myBoards.getContent());
-
-        return BoardResponse.toBoardInfo(myBoards, likeStatus);
+        Slice<BoardQueryItem> boards = boardRepository.queryFindAllMyBoards(member, pageRequest);
+        Slice<BoardResponse.BoardItem> myBoards = boards.map(BoardResponse::toBoardItem);
+        return new SliceResponse<>(myBoards);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/board/service/BoardQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/service/BoardQueryService.java
@@ -4,6 +4,8 @@ import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.board.dto.BoardResponse;
 import com.codez4.meetfolio.domain.board.repository.BoardRepository;
 import com.codez4.meetfolio.domain.board.repository.EmploymentBoardRepository;
+import com.codez4.meetfolio.domain.board.repository.GroupBoardRepository;
+import com.codez4.meetfolio.domain.enums.GroupCategory;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
@@ -23,6 +25,7 @@ public class BoardQueryService {
 
     private final BoardRepository boardRepository;
     private final EmploymentBoardRepository employmentBoardRepository;
+    private final GroupBoardRepository groupBoardRepository;
 
     public SliceResponse<BoardResponse.BoardItem> getEmploymentBoards(Member member, int page) {
         Pageable pageable = PageRequest.of(page, 6, Sort.by("id").descending());
@@ -37,6 +40,22 @@ public class BoardQueryService {
         Slice<BoardQueryItem> employmentBoards =
                 employmentBoardRepository.queryFindAllEmploymentBoardsByJobKeyword(member, jobKeyword,pageable);
         Slice<BoardResponse.BoardItem> boards = employmentBoards.map(BoardResponse::toBoardItem);
+        return new SliceResponse<>(boards);
+    }
+
+    public SliceResponse<BoardResponse.BoardItem> getGroupBoards(Member member, int page) {
+        Pageable pageable = PageRequest.of(page, 6, Sort.by("id").descending());
+        Slice<BoardQueryItem> groupBoards =
+                groupBoardRepository.queryFindAllGroupBoards(member, pageable);
+        Slice<BoardResponse.BoardItem> boards = groupBoards.map(BoardResponse::toBoardItem);
+        return new SliceResponse<>(boards);
+    }
+
+    public SliceResponse<BoardResponse.BoardItem> getGroupBoardsByGroupCategory(Member member, int page, GroupCategory groupCategory) {
+        Pageable pageable = PageRequest.of(page, 6, Sort.by("id").descending());
+        Slice<BoardQueryItem> groupBoards =
+                groupBoardRepository.queryFindAllGroupBoardsByGroupCategory(member, groupCategory,pageable);
+        Slice<BoardResponse.BoardItem> boards = groupBoards.map(BoardResponse::toBoardItem);
         return new SliceResponse<>(boards);
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/board/service/BoardQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/board/service/BoardQueryService.java
@@ -7,7 +7,6 @@ import com.codez4.meetfolio.domain.board.repository.EmploymentBoardRepository;
 import com.codez4.meetfolio.domain.board.repository.GroupBoardRepository;
 import com.codez4.meetfolio.domain.enums.GroupCategory;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
-import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,10 @@
 package com.codez4.meetfolio.domain.comment.repository;
 
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.comment.Comment;
 import com.codez4.meetfolio.domain.member.Member;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,8 +15,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     void deleteByMember(Member member);
 
-    @Query(value = "SELECT c FROM Comment c JOIN FETCH c.board WHERE c.member = :member",
-        countQuery = "SELECT COUNT(c) FROM Comment c INNER JOIN c.board WHERE c.member = :member")
-    Page<Comment> findByMemberFetchJoinBoard(@Param("member") Member member,
-        PageRequest pageRequest);
+    @Query(value = "SELECT NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(cb, cb.member.email,(SELECT l.status from Like l WHERE l.member = :member AND l.board = cb))  FROM Comment c JOIN FETCH Board cb ON cb = c.board WHERE c.member = :member ")
+    Slice<BoardQueryItem> findByMemberFetchJoinBoard(@Param("member") Member member,
+                                                     PageRequest pageRequest);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/service/CommentQueryService.java
@@ -1,22 +1,21 @@
 package com.codez4.meetfolio.domain.comment.service;
 
-import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.board.dto.BoardResponse;
-import com.codez4.meetfolio.domain.board.dto.BoardResponse.BoardInfo;
-import com.codez4.meetfolio.domain.comment.Comment;
 import com.codez4.meetfolio.domain.comment.repository.CommentRepository;
-import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.like.service.LikeQueryService;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,30 +25,24 @@ public class CommentQueryService {
     private final CommentRepository commentRepository;
     private final LikeQueryService likeQueryService;
 
-    public BoardInfo findMyComments(Member member, Integer page) {
+    public SliceResponse<BoardResponse.BoardItem> findMyComments(Member member, Integer page) {
 
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("id").descending());
-
-        // 페이징된 댓글 정보
-        Page<Comment> pageComments = commentRepository.findByMemberFetchJoinBoard(member,
-            pageRequest);
-
+        Slice<BoardQueryItem> commentBoards = commentRepository.findByMemberFetchJoinBoard(member, pageRequest);
         // 중복된 게시글 제거하기
-        List<Board> distinctBoards = getDistinctBoards(pageComments.getContent());
+        List<BoardResponse.BoardItem> distinctBoards = getDistinctBoards(commentBoards.getContent());
 
-        PageImpl<Board> pagedBoards = new PageImpl<>(distinctBoards, pageRequest,
-            distinctBoards.size());
+        SliceImpl<BoardResponse.BoardItem> boards = new SliceImpl<>(distinctBoards, pageRequest,
+                commentBoards.hasNext());
 
-        List<Status> likeStatus = likeQueryService.getLikeStatus(member, distinctBoards);
-
-        return BoardResponse.toBoardInfo(pagedBoards, likeStatus);
+        return new SliceResponse<>(boards);
     }
 
-    private List<Board> getDistinctBoards(List<Comment> comments) {
-
-        return comments.stream()
-            .map(Comment::getBoard)
+    private List<BoardResponse.BoardItem> getDistinctBoards(List<BoardQueryItem> boards) {
+        return boards.stream()
+            .map(BoardResponse::toBoardItem)
             .distinct()
-            .toList();
+                .collect(Collectors.toList());
+
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/enums/GroupCategory.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/GroupCategory.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +13,15 @@ public enum GroupCategory {
     ;
 
     private final String description;
+
+    @JsonCreator
+    public static GroupCategory convert(String source)
+    {
+        for (GroupCategory groupCategory : GroupCategory.values()) {
+            if (groupCategory.name().equals(source)) {
+                return groupCategory;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/like/repository/LikeRepository.java
@@ -1,11 +1,12 @@
 package com.codez4.meetfolio.domain.like.repository;
 
 import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.like.Like;
 import com.codez4.meetfolio.domain.member.Member;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,12 +17,12 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     void deleteByMember(Member member);
 
-    @Query(value = "SELECT l FROM Like l JOIN fetch l.board WHERE l.member = :member AND l.status = :status",
-            countQuery = "SELECT COUNT(l) FROM Like l INNER JOIN l.board WHERE l.member = :member AND l.status = :status")
-    Page<Like> findAllByMemberAndStatus(@Param("member") Member member, @Param("status") Status status, PageRequest pageRequest);
+    @Query("SELECT " +
+            "NEW com.codez4.meetfolio.domain.board.dto.BoardQueryItem(lb, lb.member.email, l.status) FROM Like l JOIN fetch Board lb ON l.board = lb  WHERE l.member = :member AND l.status = :status")
+    Slice<BoardQueryItem> findAllByMemberAndStatus(@Param("member") Member member, @Param("status") Status status, PageRequest pageRequest);
 
     // 내가 작성한 게시글의 좋아요 여부
     @Query("SELECT l.status FROM Like l WHERE l.member = :member AND l.board IN :boards")
     List<Status> findStatusByMemberAndBoards(@Param("member") Member member,
-        @Param("boards") List<Board> boards);
+                                             @Param("boards") List<Board> boards);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/like/service/LikeQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/like/service/LikeQueryService.java
@@ -1,19 +1,17 @@
 package com.codez4.meetfolio.domain.like.service;
 
-import com.codez4.meetfolio.domain.board.Board;
+import com.codez4.meetfolio.domain.board.dto.BoardQueryItem;
 import com.codez4.meetfolio.domain.board.dto.BoardResponse;
 import com.codez4.meetfolio.domain.enums.Status;
-import com.codez4.meetfolio.domain.like.Like;
 import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,24 +21,13 @@ public class LikeQueryService {
     private final LikeRepository likeRepository;
 
     // 내가 좋아요 한 게시글 목록
-    public BoardResponse.BoardInfo findMyLikedBoards(Member member, Integer page) {
+    public SliceResponse<BoardResponse.BoardItem> findMyLikedBoards(Member member, Integer page) {
 
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("id").descending());
 
-        Page<Like> pageLikes = likeRepository.findAllByMemberAndStatus(member, Status.ACTIVE,
-            pageRequest);
+        Slice<BoardQueryItem> likedBoards = likeRepository.findAllByMemberAndStatus(member, Status.ACTIVE, pageRequest);
+        Slice<BoardResponse.BoardItem> boards = likedBoards.map(BoardResponse::toBoardItem);
+        return new SliceResponse<>(boards);
 
-        List<Status> likeStatus = pageLikes.stream()
-            .map(Like::getStatus)
-            .toList();
-
-        return BoardResponse.toBoardInfo(pageLikes, likeStatus);
-
-    }
-
-    // 사용자에 따른 게시글의 좋아요 여부
-    public List<Status> getLikeStatus(Member member, List<Board> boards) {
-
-        return likeRepository.findStatusByMemberAndBoards(member, boards);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.codez4.meetfolio.domain.member.controller;
 
 import com.codez4.meetfolio.domain.board.dto.BoardResponse;
-import com.codez4.meetfolio.domain.board.dto.BoardResponse.BoardInfo;
 import com.codez4.meetfolio.domain.board.service.BoardQueryService;
 import com.codez4.meetfolio.domain.comment.service.CommentQueryService;
 import com.codez4.meetfolio.domain.enums.Grade;
@@ -16,6 +15,7 @@ import com.codez4.meetfolio.domain.member.service.MemberCommandService;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
+import com.codez4.meetfolio.global.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -73,7 +73,7 @@ public class MemberController {
                                                                 @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        BoardInfo boardInfo = boardQueryService.findMyBoards(member, page);
+        SliceResponse<BoardResponse.BoardItem> boardInfo = boardQueryService.findMyBoards(member, page);
 
         return ApiResponse.onSuccess(BoardResponse.toMyBoardResult(memberInfo, boardInfo));
     }
@@ -85,7 +85,7 @@ public class MemberController {
                                                                @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        BoardInfo boardInfo = likeQueryService.findMyLikedBoards(member, page);
+        SliceResponse<BoardResponse.BoardItem> boardInfo = likeQueryService.findMyLikedBoards(member, page);
 
         return ApiResponse.onSuccess(BoardResponse.toMyBoardResult(memberInfo, boardInfo));
     }
@@ -97,7 +97,7 @@ public class MemberController {
             @AuthenticationMember Member member, @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        BoardInfo boardInfo = commentQueryService.findMyComments(member, page);
+        SliceResponse<BoardResponse.BoardItem> boardInfo = commentQueryService.findMyComments(member, page);
 
         return ApiResponse.onSuccess(BoardResponse.toMyBoardResult(memberInfo, boardInfo));
     }

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
@@ -69,37 +69,37 @@ public class MemberController {
     @Operation(summary = "내가 작성한 게시글 목록 조회", description = "내가 작성한 게시글 목록 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/my-boards")
-    public ApiResponse<BoardResponse.MyBoardResult> getMyBoards(@AuthenticationMember Member member,
-                                                                @RequestParam(name = "page") Integer page) {
+    public ApiResponse<BoardResponse.BoardResult> getMyBoards(@AuthenticationMember Member member,
+                                                              @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         SliceResponse<BoardResponse.BoardItem> boardInfo = boardQueryService.findMyBoards(member, page);
 
-        return ApiResponse.onSuccess(BoardResponse.toMyBoardResult(memberInfo, boardInfo));
+        return ApiResponse.onSuccess(BoardResponse.toBoardResult(memberInfo, boardInfo));
     }
 
     @Operation(summary = "내가 좋아요 한 게시글 목록 조회", description = "내가 좋아요 한 게시글 목록 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/my-likes")
-    public ApiResponse<BoardResponse.MyBoardResult> getMyLikes(@AuthenticationMember Member member,
-                                                               @RequestParam(name = "page") Integer page) {
+    public ApiResponse<BoardResponse.BoardResult> getMyLikes(@AuthenticationMember Member member,
+                                                             @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         SliceResponse<BoardResponse.BoardItem> boardInfo = likeQueryService.findMyLikedBoards(member, page);
 
-        return ApiResponse.onSuccess(BoardResponse.toMyBoardResult(memberInfo, boardInfo));
+        return ApiResponse.onSuccess(BoardResponse.toBoardResult(memberInfo, boardInfo));
     }
 
     @Operation(summary = "내가 작성한 댓글의 게시글 목록 조회", description = "내가 작성한 댓글의 게시글 목록 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/my-comments")
-    public ApiResponse<BoardResponse.MyBoardResult> getMyComments(
+    public ApiResponse<BoardResponse.BoardResult> getMyComments(
             @AuthenticationMember Member member, @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         SliceResponse<BoardResponse.BoardItem> boardInfo = commentQueryService.findMyComments(member, page);
 
-        return ApiResponse.onSuccess(BoardResponse.toMyBoardResult(memberInfo, boardInfo));
+        return ApiResponse.onSuccess(BoardResponse.toBoardResult(memberInfo, boardInfo));
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/global/response/SliceResponse.java
+++ b/src/main/java/com/codez4/meetfolio/global/response/SliceResponse.java
@@ -1,0 +1,25 @@
+package com.codez4.meetfolio.global.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SliceResponse<T> implements Serializable {
+    private List<T> list;
+    private boolean hasNext;
+    private boolean isFirst;
+    private boolean isLast;
+
+    public SliceResponse(Slice<T> slice){
+        this.list = slice.getContent();
+        this.hasNext = slice.hasNext();
+        this.isFirst = slice.isFirst();
+        this.isLast = slice.isLast();
+    }
+}


### PR DESCRIPTION
## 요약

- 게시물 목록 Page 타입에서 Slice타입으로 변환

## 상세 내용

- SliceResponseDto 추가
- 엔티티와 같은 역할을 하는 BoarQueryItem dto 추가
- Paging 된 엔티티를 반환하는 repository 메소드 수정
  -> Slicing 된 BoardQueryItem 반환
- Slicing 된 BoarQueryItem을 BoardItem으로 mapping
- 취업 정보 게시판 조회 API 구현

## 질문 및 이외 사항

- 코드 봐주시고 괜찮으면 나머지 API도 이러한 방식으로 구현하려 합니다!

## 이슈 번호

- close #
