### PR TITLE
Feat : 로그인 로직 수정 및 로그아웃 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
 	// google email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -2,10 +2,10 @@ package com.codez4.meetfolio.domain.member.controller;
 
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.LoginRequest;
-import com.codez4.meetfolio.domain.member.dto.TokenResponse;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
-import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.domain.member.dto.TokenResponse;
 import com.codez4.meetfolio.domain.member.service.AuthService;
+import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.jwt.JwtAuthenticationFilter;
 import com.codez4.meetfolio.global.jwt.JwtProperties;

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -42,8 +42,8 @@ public class AuthController {
                                                                         HttpServletResponse response) {
         Member member = memberQueryService.checkEmailAndPassword(request);
         TokenResponse tokenResponse = authService.authorize(member);
-        jwtTokenProvider.setHeaderAccessToken(response, tokenResponse.getAccessToken());
-        jwtTokenProvider.setHeaderRefreshToken(response, tokenResponse.getRefreshToken());
+        jwtTokenProvider.setHeaderAccessToken(response, JwtProperties.TOKEN_PREFIX+tokenResponse.getAccessToken());
+        jwtTokenProvider.setHeaderRefreshToken(response, JwtProperties.TOKEN_PREFIX+tokenResponse.getRefreshToken());
         return ResponseEntity.ok().body(ApiResponse.onSuccess(toMemberInfo(member)));
     }
 
@@ -53,10 +53,11 @@ public class AuthController {
                          HttpServletRequest request, HttpServletResponse response) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null) {
-            response.setHeader(JwtProperties.ACCESS_HEADER_STRING, "");
             String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
             String refreshToken = JwtAuthenticationFilter.extractRefreshToken(request);
             authService.logout(accessToken, refreshToken);
+            jwtTokenProvider.setHeaderAccessToken(response, "");
+            jwtTokenProvider.setHeaderRefreshToken(response,"");
             ;
         }
         return "redirect:/main";

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -1,20 +1,35 @@
 package com.codez4.meetfolio.domain.member.controller;
 
+import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.LoginRequest;
+import com.codez4.meetfolio.domain.member.dto.LoginTokenResponse;
+import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
+import com.codez4.meetfolio.domain.member.service.AuthService;
+import com.codez4.meetfolio.global.annotation.AuthenticationMember;
+import com.codez4.meetfolio.global.jwt.JwtAuthenticationFilter;
 import com.codez4.meetfolio.global.jwt.JwtProperties;
+import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
+
+@Slf4j
 @Tag(name = "로그인/로그아웃 API")
 @RestController
 @RequestMapping("/api")
@@ -22,14 +37,33 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final MemberQueryService memberQueryService;
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    @Operation(summary = "로그인", description = "로그인")
+    @Operation(summary = "로그인", description = "로그인, 성공 시 response header access token과 refresh 토큰을, body에  로그인한 사용자 정보를 반환합니다.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<String>> login(@Valid @RequestBody LoginRequest request){
-        String jwtToken = memberQueryService.login(request);
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(JwtProperties.HEADER_STRING,JwtProperties.TOKEN_PREFIX + jwtToken);
-        return ResponseEntity.ok().headers(headers).body(ApiResponse.onSuccess("로그인에 성공하였습니다."));
+    public ResponseEntity<ApiResponse<MemberResponse.MemberInfo>> login(@Valid @RequestBody LoginRequest request,
+                                                                        HttpServletResponse response) {
+        Member member = memberQueryService.checkEmailAndPassword(request);
+        LoginTokenResponse tokenResponse = authService.authorize(member);
+        jwtTokenProvider.setHeaderAccessToken(response, tokenResponse.getAccessToken());
+        jwtTokenProvider.setHeaderRefreshToken(response, tokenResponse.getRefreshToken());
+        return ResponseEntity.ok().body(ApiResponse.onSuccess(toMemberInfo(member)));
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃")
+    @PostMapping("/logout")
+    public String logout(@AuthenticationMember Member member,
+                         HttpServletRequest request, HttpServletResponse response) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            response.setHeader(JwtProperties.ACCESS_HEADER_STRING, "");
+            String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
+            String refreshToken = JwtAuthenticationFilter.extractRefreshToken(request);
+            authService.logout(accessToken, refreshToken);
+            ;
+        }
+        return "redirect:/main/index";
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -62,16 +62,4 @@ public class AuthController {
         return "redirect:/main";
     }
 
-    @Operation(summary = "access 토큰 재발급", description = "access 토큰 만료 시 재발급 합니다.")
-    @PostMapping("/reissue")
-    public ResponseEntity<ApiResponse<MemberResponse.MemberInfo>> reissue(@AuthenticationMember Member member,
-                          HttpServletRequest request, HttpServletResponse response) {
-        String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
-        String refreshToken = JwtAuthenticationFilter.extractRefreshToken(request);
-        TokenResponse tokenResponse =authService.reissue(accessToken, refreshToken);
-        jwtTokenProvider.setHeaderAccessToken(response, tokenResponse.getAccessToken());
-        jwtTokenProvider.setHeaderRefreshToken(response, tokenResponse.getRefreshToken());
-        return ResponseEntity.ok().body(ApiResponse.onSuccess(toMemberInfo(member)));
-    }
-
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -63,7 +63,7 @@ public class AuthController {
             authService.logout(accessToken, refreshToken);
             ;
         }
-        return "redirect:/main/index";
+        return "redirect:/main";
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/LoginTokenResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/LoginTokenResponse.java
@@ -1,0 +1,11 @@
+package com.codez4.meetfolio.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginTokenResponse {
+    String accessToken;
+    String refreshToken;
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.member.dto;
 
+import com.codez4.meetfolio.domain.enums.Authority;
 import com.codez4.meetfolio.domain.member.Member;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,12 +25,15 @@ public class MemberResponse {
     @Getter
     public static class MemberInfo {
 
+        @Schema(description = "권한")
+        private String authority;
         @Schema(description = "사용자 이름")
         private String memberName;
         @Schema(description = "사용자 프로필")
         private String profile;
         @Schema(description = "사용자 학과")
         private String major;
+
     }
 
     @Schema(description = "회원 가입 완료 응답 DTO")
@@ -99,12 +103,21 @@ public class MemberResponse {
 
 
     public static MemberInfo toMemberInfo(Member member) {
-        return member == null ? null :
-                MemberInfo.builder()
-                        .memberName(member.getEmail().split("@")[0])
-                        .profile(member.getProfile())
-                        .major(member.getMajor().getDescription())
-                        .build();
+        if (member.getAuthority() == Authority.MEMBER) {
+            return MemberInfo.builder()
+                    .memberName(member.getEmail().split("@")[0])
+                    .profile(member.getProfile())
+                    .major(member.getMajor().getDescription())
+                    .build();
+        }
+        else if (member.getAuthority() == Authority.ADMIN){
+            return MemberInfo.builder()
+                    .memberName(member.getEmail())
+                    .profile(member.getProfile())
+                    .major(null)
+                    .build();
+        }
+        else return  null;
     }
 
     public static MemberListResult toMemberList(Page<Member> members) {

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/MemberResponse.java
@@ -25,7 +25,7 @@ public class MemberResponse {
     @Getter
     public static class MemberInfo {
 
-        @Schema(description = "권한")
+        @Schema(description = "권한, MEMBER/ADMIN")
         private String authority;
         @Schema(description = "사용자 이름")
         private String memberName;
@@ -105,6 +105,7 @@ public class MemberResponse {
     public static MemberInfo toMemberInfo(Member member) {
         if (member.getAuthority() == Authority.MEMBER) {
             return MemberInfo.builder()
+                    .authority(member.getAuthority().name())
                     .memberName(member.getEmail().split("@")[0])
                     .profile(member.getProfile())
                     .major(member.getMajor().getDescription())
@@ -112,6 +113,7 @@ public class MemberResponse {
         }
         else if (member.getAuthority() == Authority.ADMIN){
             return MemberInfo.builder()
+                    .authority(member.getAuthority().name())
                     .memberName(member.getEmail())
                     .profile(member.getProfile())
                     .major(null)

--- a/src/main/java/com/codez4/meetfolio/domain/member/dto/TokenResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/dto/TokenResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class LoginTokenResponse {
+public class TokenResponse {
     String accessToken;
     String refreshToken;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AuthService {
 
-    private final MemberQueryService memberQueryService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
 

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.codez4.meetfolio.domain.member.service;
 
 import com.codez4.meetfolio.domain.member.Member;
-import com.codez4.meetfolio.domain.member.dto.LoginTokenResponse;
+import com.codez4.meetfolio.domain.member.dto.TokenResponse;
+import com.codez4.meetfolio.global.exception.ApiException;
+import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.codez4.meetfolio.global.utils.RedisUtil;
 import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -15,26 +17,38 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AuthService {
 
+    private final MemberQueryService memberQueryService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
 
-    public LoginTokenResponse authorize(Member member) {
+    public TokenResponse authorize(Member member) {
+        TokenResponse tokenResponse = generateToken(member);
+        redisUtil.set(tokenResponse.getRefreshToken(), String.valueOf(member.getId()), 180);
+        return tokenResponse;
+    }
+
+    private TokenResponse generateToken(Member member) {
         String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getId(), member.getAuthority());
         String refreshToken = jwtTokenProvider.generateRefreshToken();
-        log.info("access {}", accessToken);
-        log.info("refresh {}", refreshToken);
-        redisUtil.set(refreshToken, String.valueOf(member.getId()), 180);
-
-        LoginTokenResponse response = LoginTokenResponse.builder()
+        return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
-        return response;
     }
 
 
     public void logout(String accessToken, String refreshToken){
         redisUtil.delete(refreshToken);
         redisUtil.setBlackList(accessToken, "accessToken", 1800L);
+    }
+
+    public TokenResponse reissue(String accessToken, String refreshToken){
+        if(!jwtTokenProvider.validateToken(refreshToken)){
+            throw new ApiException(ErrorStatus._INVALID_TOKEN);
+        };
+        Long memberId = Long.valueOf(redisUtil.get(refreshToken));
+        log.info("memberId {}", memberId);
+        Member member = memberQueryService.findById(memberId);
+        return generateToken(member);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
@@ -2,10 +2,8 @@ package com.codez4.meetfolio.domain.member.service;
 
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.TokenResponse;
-import com.codez4.meetfolio.global.exception.ApiException;
-import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
-import com.codez4.meetfolio.global.utils.RedisUtil;
 import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
+import com.codez4.meetfolio.global.utils.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,15 +38,5 @@ public class AuthService {
     public void logout(String accessToken, String refreshToken){
         redisUtil.delete(refreshToken);
         redisUtil.setBlackList(accessToken, "accessToken", 1800L);
-    }
-
-    public TokenResponse reissue(String accessToken, String refreshToken){
-        if(!jwtTokenProvider.validateToken(refreshToken)){
-            throw new ApiException(ErrorStatus._INVALID_TOKEN);
-        };
-        Long memberId = Long.valueOf(redisUtil.get(refreshToken));
-        log.info("memberId {}", memberId);
-        Member member = memberQueryService.findById(memberId);
-        return generateToken(member);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
@@ -1,0 +1,40 @@
+package com.codez4.meetfolio.domain.member.service;
+
+import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.member.dto.LoginTokenResponse;
+import com.codez4.meetfolio.global.utils.RedisUtil;
+import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
+
+    public LoginTokenResponse authorize(Member member) {
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getId(), member.getAuthority());
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+        log.info("access {}", accessToken);
+        log.info("refresh {}", refreshToken);
+        redisUtil.set(refreshToken, String.valueOf(member.getId()), 180);
+
+        LoginTokenResponse response = LoginTokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        return response;
+    }
+
+
+    public void logout(String accessToken, String refreshToken){
+        redisUtil.delete(refreshToken);
+        redisUtil.setBlackList(accessToken, "accessToken", 1800L);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -6,14 +6,11 @@ import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
 import com.codez4.meetfolio.domain.member.repository.MemberRepository;
 import com.codez4.meetfolio.global.exception.ApiException;
-import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.codez4.meetfolio.global.security.Password;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
 import static com.codez4.meetfolio.global.security.Password.ENCODER;

--- a/src/main/java/com/codez4/meetfolio/global/annotation/AuthenticationMemberArgumentResolver.java
+++ b/src/main/java/com/codez4/meetfolio/global/annotation/AuthenticationMemberArgumentResolver.java
@@ -35,19 +35,19 @@ public class AuthenticationMemberArgumentResolver implements HandlerMethodArgume
 
         // 비로그인 / 로그인 경로 예외
         if (request.getServletPath().equals("/api")
-            && JwtAuthenticationFilter.resolveToken(request) == null) {
+            && JwtAuthenticationFilter.extractAccessToken(request) == null) {
             return null;
         }
 
-        String token = JwtAuthenticationFilter.resolveToken(request);
+        String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
 
-        if (token.isEmpty() || token.isBlank()) {
+        if (accessToken.isEmpty() || accessToken.isBlank()) {
             throw new ApiException(ErrorStatus._FORBIDDEN);
         }
 
-        validateTokenIntegrity(token);
+        validateTokenIntegrity(accessToken);
 
-        Long memberId = jwtTokenProvider.getUserId(token);
+        Long memberId = jwtTokenProvider.getUserId(accessToken);
 
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));

--- a/src/main/java/com/codez4/meetfolio/global/config/RedisConfig.java
+++ b/src/main/java/com/codez4/meetfolio/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.codez4.meetfolio.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtAuthenticationFilter.java
@@ -62,7 +62,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     Member member = memberRepository.findById(memberId)
                             .orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
                     String newAccessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), memberId, member.getAuthority());
-                    jwtTokenProvider.setHeaderAccessToken(response, newAccessToken);
+                    jwtTokenProvider.setHeaderAccessToken(response, JwtProperties.TOKEN_PREFIX + newAccessToken);
                     SecurityContextHolder.getContext().setAuthentication(jwtTokenProvider.getAuthentication(newAccessToken));
                 }
             }

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtExceptionFilter.java
@@ -4,7 +4,6 @@ import com.codez4.meetfolio.global.response.code.ErrorReasonDto;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtExceptionFilter.java
@@ -3,6 +3,7 @@ package com.codez4.meetfolio.global.jwt;
 import com.codez4.meetfolio.global.response.code.ErrorReasonDto;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,7 +29,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (JwtException jwtException) {
+        } catch (ExpiredJwtException jwtException) {
             setErrorResponse(ErrorStatus._INVALID_TOKEN, response, jwtException);
         } catch (UsernameNotFoundException usernameNotFoundException) {
             setErrorResponse(ErrorStatus._MEMBER_NOT_FOUND, response, usernameNotFoundException);

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtProperties.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtProperties.java
@@ -2,5 +2,7 @@ package com.codez4.meetfolio.global.jwt;
 
 public interface JwtProperties {
     String TOKEN_PREFIX = "Bearer ";
-    String HEADER_STRING = "Authorization";
+    String ACCESS_HEADER_STRING = "Authorization";
+
+    String REFRESH_HEADER_STRING = "RefreshToken";
 }

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
@@ -1,10 +1,10 @@
 package com.codez4.meetfolio.global.jwt;
 
 import com.codez4.meetfolio.domain.enums.Authority;
-import com.codez4.meetfolio.global.utils.RedisUtil;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.codez4.meetfolio.global.security.CustomUserDetailService;
+import com.codez4.meetfolio.global.utils.RedisUtil;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
@@ -1,12 +1,14 @@
 package com.codez4.meetfolio.global.jwt;
 
 import com.codez4.meetfolio.domain.enums.Authority;
+import com.codez4.meetfolio.global.utils.RedisUtil;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import com.codez4.meetfolio.global.security.CustomUserDetailService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -25,11 +27,20 @@ public class JwtTokenProvider {
     private final Key key;
 
     @Value("${application.jwt.access_token_expire}")
-    private long TOKEN_EXPIRE_TIME;
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${application.jwt.refresh_token_expire}")
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+
     private final CustomUserDetailService customUserDetailService;
 
-    public JwtTokenProvider(@Value("${application.jwt.secret_key}") String secretKey,
-                            CustomUserDetailService customUserDetailService) {
+    @Value("${application.jwt.secret_key}")
+    private String secretKey;
+    private final RedisUtil redisUtil;
+
+    public JwtTokenProvider(@Value("${application.jwt.secret_key}")
+                              String secretKey, CustomUserDetailService customUserDetailService, RedisUtil redisUtil) {
+        this.redisUtil = redisUtil;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.customUserDetailService = customUserDetailService;
@@ -44,13 +55,26 @@ public class JwtTokenProvider {
      * payload "exp" : "123456789"
      * header "alg" : "HS512"
      */
-    public String generate(String email, Long userId, Authority authority) {
+    public String generateAccessToken(String email, Long memberId, Authority authority) {
         long now = (new Date()).getTime();
-        Date expiredAt = new Date(now + TOKEN_EXPIRE_TIME);
+        Date expiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
         return Jwts.builder()
                 .setSubject(email)
-                .claim(USER_ID_KEY, userId)
+                .claim(USER_ID_KEY, memberId)
                 .claim(AUTHORITIES_KEY, authority.getDescription())
+                .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
+                .setExpiration(expiredAt)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String generateRefreshToken() {
+        long now = (new Date()).getTime();
+        Date expiredAt = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+        Claims claims = Jwts
+                .claims();
+        return Jwts.builder()
+                .setClaims(claims)
                 .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
                 .setExpiration(expiredAt)
                 .signWith(key, SignatureAlgorithm.HS512)
@@ -60,6 +84,15 @@ public class JwtTokenProvider {
     public Long getUserId(String token) {
         return parseClaims(token)
                 .get(USER_ID_KEY, Long.class);
+    }
+
+    public Long getExpiration(String token){
+
+        Date expiration = Jwts.parserBuilder().setSigningKey(secretKey)
+                .build().parseClaimsJws(token).getBody().getExpiration();
+
+        long now = new Date().getTime();
+        return expiration.getTime() - now;
     }
 
     public Claims parseClaims(String token) {
@@ -77,11 +110,14 @@ public class JwtTokenProvider {
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            if(redisUtil.hasKeyBlackList(token)){
+                throw new RuntimeException("이미 탈퇴한 회원입니다.");
+            }
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             throw new JwtException("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
-            throw new JwtException("만료된 JWT 토큰입니다.");
+            throw new JwtException("만료된 Access 토큰입니다.");
         } catch (UnsupportedJwtException e) {
             throw new JwtException("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
@@ -98,5 +134,16 @@ public class JwtTokenProvider {
         UserDetails userDetails = customUserDetailService.loadUserByUsername(claims.get(USER_ID_KEY, Long.class).toString());
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+    public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
+        response.setHeader(JwtProperties.ACCESS_HEADER_STRING, JwtProperties.TOKEN_PREFIX+ accessToken);
+    }
+
+    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
+        response.setHeader(JwtProperties.REFRESH_HEADER_STRING, JwtProperties.TOKEN_PREFIX+ refreshToken);
+    }
+
+    public boolean existsRefreshToken(String refreshToken) {
+        return redisUtil.hasKey(refreshToken);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/codez4/meetfolio/global/jwt/JwtTokenProvider.java
@@ -136,11 +136,11 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
     public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
-        response.setHeader(JwtProperties.ACCESS_HEADER_STRING, JwtProperties.TOKEN_PREFIX+ accessToken);
+        response.setHeader(JwtProperties.ACCESS_HEADER_STRING, accessToken);
     }
 
     public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
-        response.setHeader(JwtProperties.REFRESH_HEADER_STRING, JwtProperties.TOKEN_PREFIX+ refreshToken);
+        response.setHeader(JwtProperties.REFRESH_HEADER_STRING, refreshToken);
     }
 
     public boolean existsRefreshToken(String refreshToken) {

--- a/src/main/java/com/codez4/meetfolio/global/utils/RedisUtil.java
+++ b/src/main/java/com/codez4/meetfolio/global/utils/RedisUtil.java
@@ -2,7 +2,6 @@ package com.codez4.meetfolio.global.utils;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/codez4/meetfolio/global/utils/RedisUtil.java
+++ b/src/main/java/com/codez4/meetfolio/global/utils/RedisUtil.java
@@ -1,0 +1,52 @@
+package com.codez4.meetfolio.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisBlackListTemplate;
+
+    public void set(String key, Object o, int minutes) {
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+    }
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void setBlackList(String key, Object o, Long milliSeconds) {
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisBlackListTemplate.setValueSerializer(new StringRedisSerializer());
+        redisBlackListTemplate.opsForValue().set(key, o, milliSeconds, TimeUnit.MILLISECONDS);
+    }
+
+    public Object getBlackList(String key) {
+        return redisBlackListTemplate.opsForValue().get(key);
+    }
+
+    public boolean deleteBlackList(String key) {
+        return redisBlackListTemplate.delete(key);
+    }
+
+    public boolean hasKeyBlackList(String key) {
+        return redisBlackListTemplate.hasKey(key);
+    }
+}

--- a/src/main/java/com/codez4/meetfolio/global/utils/RedisUtil.java
+++ b/src/main/java/com/codez4/meetfolio/global/utils/RedisUtil.java
@@ -11,17 +11,17 @@ import java.util.concurrent.TimeUnit;
 @Component
 @RequiredArgsConstructor
 public class RedisUtil {
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final RedisTemplate<String, Object> redisBlackListTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String,String> redisBlackListTemplate;
 
-    public void set(String key, Object o, int minutes) {
+    public void set(String key, String value, int minutes) {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-        redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(key, value, minutes, TimeUnit.MINUTES);
     }
 
-    public Object get(String key) {
-        return redisTemplate.opsForValue().get(key);
+    public String get(String key) {
+        return (String) redisTemplate.opsForValue().get(key);
     }
 
     public boolean delete(String key) {
@@ -32,10 +32,10 @@ public class RedisUtil {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    public void setBlackList(String key, Object o, Long milliSeconds) {
+    public void setBlackList(String key, String value, Long milliSeconds) {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisBlackListTemplate.setValueSerializer(new StringRedisSerializer());
-        redisBlackListTemplate.opsForValue().set(key, o, milliSeconds, TimeUnit.MILLISECONDS);
+        redisBlackListTemplate.opsForValue().set(key, value, milliSeconds, TimeUnit.MILLISECONDS);
     }
 
     public Object getBlackList(String key) {

--- a/src/test/java/com/codez4/meetfolio/MeetfolioApplicationTests.java
+++ b/src/test/java/com/codez4/meetfolio/MeetfolioApplicationTests.java
@@ -1,13 +1,15 @@
 package com.codez4.meetfolio;
 
+import com.codez4.meetfolio.domain.emailAuth.controller.EmailAuthController;
+import com.codez4.meetfolio.domain.emailAuth.dto.EmailRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class MeetfolioApplicationTests {
+@Autowired
+public EmailAuthController emailAuthController;
 
-	@Test
-	void contextLoads() {
-	}
 
 }


### PR DESCRIPTION
## 요약

- 로그인 로직 수정 및 로그아웃 API 구현

## 상세 내용

- 로그인 API 로직 수정
  - access 토큰 및 refresh 토큰 발급
  - response header에 access 토큰 및 refresh 토큰 전송
- 로그아웃 API 구현
  - 로그아웃 시 refresh 토큰 redis에서 삭제
  - Redis blacklist 저장소에 access 토큰 등록
- member 인증 로직 수정
  - client 단에서 request header에 access 토큰 및 **refresh 토큰** 담아 요청
  -> access 토큰 검증
  -> +new) access 토큰 기한 만료 시 refresh 토큰 검증 
  -> +new)refresh 토큰 기한 만료 시 access, refresh 토큰 재발급
- MemberInfo class에 권한 정보 추가

## 질문 및 이외 사항

- redis 저장소 추가에 따른 docker file 수정 필요합니다! 이슈 및 PR 생성해서 올리도록 하겠습니다.
- access , refresh 토큰 만료 시간은 어떻게 할까요?

## 이슈 번호

- close #19 
