### PR TITLE
Feat: 자기소개서 및 사용자 정보 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -6,8 +6,21 @@ import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.enums.ShareType;
 import com.codez4.meetfolio.domain.enums.Status;
 import com.codez4.meetfolio.domain.member.Member;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -40,7 +53,6 @@ public class CoverLetter extends BaseTimeEntity {
     @Column(name = "keyword_2")
     private String keyword2;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private JobKeyword jobKeyword;
 
@@ -56,7 +68,7 @@ public class CoverLetter extends BaseTimeEntity {
     /**
      * update
      */
-    public void update(CoverLetterRequest request) {
+    public void update(CoverLetterRequest.Patch request) {
         this.question = request.getQuestion();
         this.answer = request.getAnswer();
         this.shareType = ShareType.convert(request.getShareType());

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -14,6 +14,7 @@ import com.codez4.meetfolio.domain.feedback.service.FeedbackQueryService;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
+import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import com.codez4.meetfolio.global.response.SliceResponse;
@@ -23,7 +24,15 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "자기소개서 API")
 @RestController
@@ -35,20 +44,21 @@ public class CoverLetterController {
     private final CoverLetterCommandService coverLetterCommandService;
     private final FeedbackQueryService feedbackQueryService;
     private final AnalysisQueryService analysisQueryService;
+    private final MemberQueryService memberQueryService;
 
 
     @Operation(summary = "자기소개서 상세정보 조회", description = "특정 자기소개서 정보를 조회합니다.")
     @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/{coverLetterId}")
     public ApiResponse<CoverLetterResult> getCoverLetter(@AuthenticationMember Member member,
-                                                         @PathVariable(name = "coverLetterId") Long coverLetterId) {
+        @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(coverLetterId);
         FeedbackInfo feedbackInfo = feedbackQueryService.getFeedbackInfo(coverLetterId);
         AnalysisInfo analysisInfo = analysisQueryService.getAnalysisInfo(coverLetterId);
         CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(memberInfo,
-                coverLetterInfo, feedbackInfo, analysisInfo);
+            coverLetterInfo, feedbackInfo, analysisInfo);
 
         return ApiResponse.onSuccess(coverLetterResult);
     }
@@ -56,7 +66,7 @@ public class CoverLetterController {
     @Operation(summary = "자기소개서 작성 요청", description = "로그인 사용자는 자기소개서를 작성합니다.")
     @PostMapping
     public ApiResponse<CoverLetterProc> createCoverLetter(@AuthenticationMember Member member,
-                                                          @Valid @RequestBody CoverLetterRequest request) {
+        @Valid @RequestBody CoverLetterRequest request) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.write(member, request));
     }
@@ -65,8 +75,8 @@ public class CoverLetterController {
     @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @PatchMapping("/{coverLetterId}")
     public ApiResponse<CoverLetterProc> updateCoverLetter(
-            @PathVariable(name = "coverLetterId") Long coverLetterId,
-            @Valid @RequestBody CoverLetterRequest request) {
+        @PathVariable(name = "coverLetterId") Long coverLetterId,
+        @Valid @RequestBody CoverLetterRequest request) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.update(coverLetterId, request));
     }
@@ -75,15 +85,28 @@ public class CoverLetterController {
     @Parameter(name = "coverLetterId", description = "자기소개서 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @DeleteMapping("/{coverLetterId}")
     public ApiResponse<CoverLetterProc> deleteCoverLetter(
-            @PathVariable(name = "coverLetterId") Long coverLetterId) {
+        @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.softDelete(coverLetterId));
     }
 
     @Operation(summary = "내 자기소개서 목록 조회", description = "내 자기소개서 목록 정보를 조회합니다.")
     @GetMapping
-    public ApiResponse<SliceResponse<CoverLetterResponse.CoverLetterItem>> getMyCoverLetters(@AuthenticationMember Member member,
-                                                                                             @RequestParam(value = "page", defaultValue = "0") int page) {
+    public ApiResponse<SliceResponse<CoverLetterResponse.CoverLetterItem>> getMyCoverLetters(
+        @AuthenticationMember Member member,
+        @RequestParam(value = "page", defaultValue = "0") int page) {
         return ApiResponse.onSuccess(coverLetterQueryService.getMyCoverLetters(member, page));
+    }
+
+    @Operation(summary = "다른 사용자의 자기소개서 목록 조회", description = "타 사용자의 자기소개서 목록 정보를 조회합니다.")
+    @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
+    @PostMapping("/members")
+    public ApiResponse<SliceResponse<CoverLetterResponse.CoverLetterItem>> getOtherCoverLetters(
+        @RequestBody String memberName,
+        @RequestParam(value = "page", defaultValue = "0") int page) {
+
+        Member other = memberQueryService.findByMemberName(memberName);
+
+        return ApiResponse.onSuccess(coverLetterQueryService.getOtherCoverLetters(other, page));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -66,7 +66,7 @@ public class CoverLetterController {
     @Operation(summary = "자기소개서 작성 요청", description = "로그인 사용자는 자기소개서를 작성합니다.")
     @PostMapping
     public ApiResponse<CoverLetterProc> createCoverLetter(@AuthenticationMember Member member,
-        @Valid @RequestBody CoverLetterRequest request) {
+        @Valid @RequestBody CoverLetterRequest.Post request) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.write(member, request));
     }
@@ -76,7 +76,7 @@ public class CoverLetterController {
     @PatchMapping("/{coverLetterId}")
     public ApiResponse<CoverLetterProc> updateCoverLetter(
         @PathVariable(name = "coverLetterId") Long coverLetterId,
-        @Valid @RequestBody CoverLetterRequest request) {
+        @Valid @RequestBody CoverLetterRequest.Patch request) {
 
         return ApiResponse.onSuccess(coverLetterCommandService.update(coverLetterId, request));
     }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -3,6 +3,7 @@ package com.codez4.meetfolio.domain.coverLetter.controller;
 import com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
 import com.codez4.meetfolio.domain.analysis.service.AnalysisQueryService;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest;
+import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterRequest.CoverLetterOther;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterInfo;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterProc;
@@ -102,10 +103,10 @@ public class CoverLetterController {
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @PostMapping("/members")
     public ApiResponse<SliceResponse<CoverLetterResponse.CoverLetterItem>> getOtherCoverLetters(
-        @RequestBody String memberName,
+        @RequestBody CoverLetterOther otherMember,
         @RequestParam(value = "page", defaultValue = "0") int page) {
 
-        Member other = memberQueryService.findByMemberName(memberName);
+        Member other = memberQueryService.findByMemberName(otherMember.getMemberName());
 
         return ApiResponse.onSuccess(coverLetterQueryService.getOtherCoverLetters(other, page));
     }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
@@ -59,4 +59,11 @@ public class CoverLetterRequest {
             .member(member)
             .build();
     }
+
+    @Getter
+    public static class CoverLetterOther {
+
+        @Schema(description = "다른 사용자의 이름 (이메일 정보는 백엔드에서 처리)")
+        private String memberName;
+    }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
@@ -8,39 +8,54 @@ import com.codez4.meetfolio.global.annotation.EnumValid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(description = "자기소개서 작성 & 수정 DTO")
-@Getter
 public class CoverLetterRequest {
 
-    @Schema(description = "자기소개서 문항")
-    private String question;
+    @Schema(name = "CoverLetterPost", description = "자기소개서 작성 DTO")
+    @Getter
+    public static class Post {
 
-    @Schema(description = "자기소개서 답변")
-    private String answer;
+        @Schema(description = "자기소개서 문항")
+        private String question;
 
-    @Schema(description = "자기소개서 공개 여부, PUBLIC / PRIVATE", example = "PUBLIC")
-    @EnumValid(enumClass = ShareType.class)
-    private String shareType;
+        @Schema(description = "자기소개서 답변")
+        private String answer;
 
-    @Schema(description = "나의 역량 키워드 1")
-    private String keyword1;
+        @Schema(description = "자기소개서 공개 여부, PUBLIC / PRIVATE", example = "PUBLIC")
+        @EnumValid(enumClass = ShareType.class)
+        private String shareType;
+    }
 
-    @Schema(description = "나의 역량 키워드 2")
-    private String keyword2;
+    @Schema(name = "CoverLetterPatch", description = "자기소개서 수정 DTO")
+    @Getter
+    public static class Patch {
 
-    @Schema(description = "자기소개서 지원 직무, BACKEND/WEB/APP/DESIGN/AI", example = "BACKEND")
-    @EnumValid(enumClass = JobKeyword.class)
-    private String jobKeyword;
+        @Schema(description = "자기소개서 문항")
+        private String question;
 
-    public static CoverLetter toEntity(Member member, CoverLetterRequest request) {
+        @Schema(description = "자기소개서 답변")
+        private String answer;
+
+        @Schema(description = "자기소개서 공개 여부, PUBLIC / PRIVATE", example = "PUBLIC")
+        @EnumValid(enumClass = ShareType.class)
+        private String shareType;
+
+        @Schema(description = "나의 역량 키워드 1")
+        private String keyword1;
+
+        @Schema(description = "나의 역량 키워드 2")
+        private String keyword2;
+
+        @Schema(description = "자기소개서 지원 직무, BACKEND/WEB/APP/DESIGN/AI", example = "BACKEND")
+        @EnumValid(enumClass = JobKeyword.class)
+        private String jobKeyword;
+    }
+
+    public static CoverLetter toEntity(Member member, CoverLetterRequest.Post request) {
 
         return CoverLetter.builder()
             .question(request.getQuestion())
             .answer(request.getAnswer())
             .shareType(ShareType.convert(request.getShareType()))
-            .keyword1(request.getKeyword1())
-            .keyword2(request.getKeyword2())
-            .jobKeyword(JobKeyword.convert(request.getJobKeyword()))
             .member(member)
             .build();
     }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -1,18 +1,19 @@
 package com.codez4.meetfolio.domain.coverLetter.dto;
 
+import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
+import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
+
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse.MemberInfo;
+import com.codez4.meetfolio.global.response.SliceResponse;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-
-import static com.codez4.meetfolio.domain.analysis.dto.AnalysisResponse.AnalysisInfo;
-import static com.codez4.meetfolio.domain.feedback.dto.FeedbackResponse.FeedbackInfo;
+import org.springframework.data.domain.Slice;
 
 public class CoverLetterResponse {
 
@@ -48,14 +49,14 @@ public class CoverLetterResponse {
     public static CoverLetterInfo toCoverLetterInfo(CoverLetter coverLetter) {
 
         return CoverLetterInfo.builder()
-                .coverLetterId(coverLetter.getId())
-                .question(coverLetter.getQuestion())
-                .answer(coverLetter.getAnswer())
-                .shareType(coverLetter.getShareType().getDescription())
-                .keyword1(coverLetter.getKeyword1())
-                .keyword2(coverLetter.getKeyword2())
-                .jobKeyword(coverLetter.getJobKeyword().getDescription())
-                .build();
+            .coverLetterId(coverLetter.getId())
+            .question(coverLetter.getQuestion())
+            .answer(coverLetter.getAnswer())
+            .shareType(coverLetter.getShareType().getDescription())
+            .keyword1(coverLetter.getKeyword1())
+            .keyword2(coverLetter.getKeyword2())
+            .jobKeyword(coverLetter.getJobKeyword().getDescription())
+            .build();
 
     }
 
@@ -73,15 +74,15 @@ public class CoverLetterResponse {
     }
 
     public static CoverLetterResult toCoverLetterResult(MemberInfo memberInfo,
-                                                        CoverLetterInfo coverLetterInfo,
-                                                        FeedbackInfo feedbackInfo, AnalysisInfo analysisInfo) {
+        CoverLetterInfo coverLetterInfo,
+        FeedbackInfo feedbackInfo, AnalysisInfo analysisInfo) {
 
         return CoverLetterResult.builder()
-                .memberInfo(memberInfo)
-                .coverLetterInfo(coverLetterInfo)
-                .feedbackInfo(feedbackInfo)
-                .analysisInfo(analysisInfo)
-                .build();
+            .memberInfo(memberInfo)
+            .coverLetterInfo(coverLetterInfo)
+            .feedbackInfo(feedbackInfo)
+            .analysisInfo(analysisInfo)
+            .build();
     }
 
     @Schema(description = "자기소개서 응답 DTO")
@@ -107,12 +108,21 @@ public class CoverLetterResponse {
 
     public static CoverLetterItem toCoverLetterItem(CoverLetter coverLetter) {
         return CoverLetterItem.builder()
-                .coverLetterId(coverLetter.getId())
-                .question(coverLetter.getQuestion())
-                .answer(coverLetter.getAnswer())
-                .createdAt(coverLetter.getCreatedAt())
-                .build();
+            .coverLetterId(coverLetter.getId())
+            .question(coverLetter.getQuestion())
+            .answer(coverLetter.getAnswer())
+            .createdAt(coverLetter.getCreatedAt())
+            .build();
 
+    }
+
+    public static SliceResponse<CoverLetterItem> toSliceCoverLetterItem(
+        Slice<CoverLetter> coverLetters) {
+
+        Slice<CoverLetterItem> coverLetterItems = coverLetters.map(
+            CoverLetterResponse::toCoverLetterItem);
+
+        return new SliceResponse<>(coverLetterItems);
     }
 
     @Schema(description = "자기소개서 작성 & 수정 & 삭제 응답 DTO")
@@ -120,6 +130,7 @@ public class CoverLetterResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
+
     public static class CoverLetterProc {
 
         @Schema(description = "자기소개서 아이디")
@@ -131,9 +142,9 @@ public class CoverLetterResponse {
 
     public static CoverLetterProc toCoverLetterProc(Long coverLetterId) {
         return CoverLetterProc.builder()
-                .coverLetterId(coverLetterId)
-                .createdAt(LocalDateTime.now())
-                .build();
+            .coverLetterId(coverLetterId)
+            .createdAt(LocalDateTime.now())
+            .build();
     }
 }
 

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
@@ -2,14 +2,18 @@ package com.codez4.meetfolio.domain.coverLetter.repository;
 
 import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.member.Member;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
+
     List<CoverLetter> findByMember(Member member);
 
     Slice<CoverLetter> findByMember(Member member, Pageable pageable);
+
+    @Query("SELECT c FROM CoverLetter c WHERE c.member = :member and c.shareType = 'PUBLIC' and c.status = 'ACTIVE'")
+    Slice<CoverLetter> findPublicAndActiveCoverLetterByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -22,7 +22,7 @@ public class CoverLetterCommandService {
     private final AnalysisCommandService analysisCommandService;
     private final FeedbackCommandService feedbackCommandService;
 
-    public CoverLetterProc write(Member member, CoverLetterRequest request) {
+    public CoverLetterProc write(Member member, CoverLetterRequest.Post request) {
 
         CoverLetter coverLetter = save(CoverLetterRequest.toEntity(member, request));
 
@@ -34,7 +34,7 @@ public class CoverLetterCommandService {
         return coverLetterRepository.save(coverLetter);
     }
 
-    public CoverLetterProc update(Long coverLetterId, CoverLetterRequest request) {
+    public CoverLetterProc update(Long coverLetterId, CoverLetterRequest.Patch request) {
         CoverLetter coverLetter = coverLetterQueryService.findById(coverLetterId);
         coverLetter.update(request);
         return CoverLetterResponse.toCoverLetterProc(coverLetterId);

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
@@ -45,7 +45,8 @@ public class CoverLetterQueryService {
         int page) {
         PageRequest pageRequest = PageRequest.of(page, 4, Sort.by("createdAt").descending());
 
-        Slice<CoverLetter> otherCoverLetters = coverLetterRepository.findByMember(other,
+        Slice<CoverLetter> otherCoverLetters = coverLetterRepository.findPublicAndActiveCoverLetterByMember(
+            other,
             pageRequest);
         return CoverLetterResponse.toSliceCoverLetterItem(otherCoverLetters);
     }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
@@ -30,14 +30,23 @@ public class CoverLetterQueryService {
 
     public CoverLetter findById(Long coverLetterId) {
         return coverLetterRepository.findById(coverLetterId).orElseThrow(
-                () -> new ApiException(ErrorStatus._COVERLETTER_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._COVERLETTER_NOT_FOUND)
         );
     }
 
-    public SliceResponse<CoverLetterResponse.CoverLetterItem> getMyCoverLetters(Member member, int page) {
+    public SliceResponse<CoverLetterResponse.CoverLetterItem> getMyCoverLetters(Member member,
+        int page) {
         PageRequest pageRequest = PageRequest.of(page, 4, Sort.by("createdAt").descending());
         Slice<CoverLetter> coverLetters = coverLetterRepository.findByMember(member, pageRequest);
-        Slice<CoverLetterResponse.CoverLetterItem> coverLetterInfo = coverLetters.map(CoverLetterResponse::toCoverLetterItem);
-        return new SliceResponse<>(coverLetterInfo);
+        return CoverLetterResponse.toSliceCoverLetterItem(coverLetters);
+    }
+
+    public SliceResponse<CoverLetterResponse.CoverLetterItem> getOtherCoverLetters(Member other,
+        int page) {
+        PageRequest pageRequest = PageRequest.of(page, 4, Sort.by("createdAt").descending());
+
+        Slice<CoverLetter> otherCoverLetters = coverLetterRepository.findByMember(other,
+            pageRequest);
+        return CoverLetterResponse.toSliceCoverLetterItem(otherCoverLetters);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/experience/controller/ExperienceController.java
@@ -1,5 +1,16 @@
 package com.codez4.meetfolio.domain.experience.controller;
 
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardInfo;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardItem;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceCardResult;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceInfo;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceProc;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.ExperienceResult;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.RecommendCard;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceCardResult;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toExperienceResult;
+import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.toRecommendCard;
+
 import com.codez4.meetfolio.domain.experience.dto.ExperienceRequest;
 import com.codez4.meetfolio.domain.experience.service.ExperienceCommandService;
 import com.codez4.meetfolio.domain.experience.service.ExperienceQueryService;
@@ -12,12 +23,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
-
-import static com.codez4.meetfolio.domain.experience.dto.ExperienceResponse.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "경험 분해 API")
 @RestController
@@ -61,7 +77,7 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 수정", description = "경험 분해 수정 요청을 PATCH로 보냅니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @PatchMapping("/experiences{experienceId}")
+    @PatchMapping("/experiences/{experienceId}")
     public ApiResponse<ExperienceProc> patch(@RequestBody ExperienceRequest patch,
         @PathVariable(name = "experienceId") Long experienceId) {
 
@@ -70,7 +86,7 @@ public class ExperienceController {
 
     @Operation(summary = "경험 분해 삭제", description = "경험 분해 삭제 요청을 DELETE로 보냅니다.")
     @Parameter(name = "experienceId", description = "경험 분해 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @DeleteMapping("/experiences{experienceId}")
+    @DeleteMapping("/experiences/{experienceId}")
     public ApiResponse<ExperienceProc> delete(
         @PathVariable(name = "experienceId") Long experienceId) {
 

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/MemberController.java
@@ -21,7 +21,13 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "사용자 API")
 @RestController
@@ -38,21 +44,21 @@ public class MemberController {
     @Operation(summary = "회원 가입", description = "회원 가입")
     @PostMapping("/signup")
     public ApiResponse<MemberResponse.MemberProc> signUp(
-            @Valid @RequestBody MemberRequest.SignUpRequest request) {
+        @Valid @RequestBody MemberRequest.SignUpRequest request) {
         MemberRequest.Post post = MemberRequest.Post.builder()
-                .email(request.getEmail())
-                .password(request.getPassword())
-                .grade(Grade.convert(request.getGrade()))
-                .jobKeyword(JobKeyword.convert(request.getJobKeyword()))
-                .major(request.getMajor())
-                .build();
+            .email(request.getEmail())
+            .password(request.getPassword())
+            .grade(Grade.convert(request.getGrade()))
+            .jobKeyword(JobKeyword.convert(request.getJobKeyword()))
+            .major(request.getMajor())
+            .build();
         return ApiResponse.onSuccess(memberCommandService.post(post));
     }
 
     @Operation(summary = "마이페이지 수정 정보 조회", description = "사용자의 개인 정보를 조회합니다.")
     @GetMapping("/mypage")
     public ApiResponse<MemberResponse.MemberDetailInfo> myPage(
-            @AuthenticationMember Member member) {
+        @AuthenticationMember Member member) {
 
         return ApiResponse.onSuccess(memberQueryService.getMyPage(member));
     }
@@ -60,7 +66,7 @@ public class MemberController {
     @Operation(summary = "마이페이지 수정 요청", description = "사용자의 개인 정보를 수정합니다.")
     @PatchMapping("/mypage")
     public ApiResponse<MemberResponse.MemberProc> editMyPage(@AuthenticationMember Member member,
-                                                             @RequestBody MemberRequest.Patch patch) {
+        @RequestBody MemberRequest.Patch patch) {
 
         return ApiResponse.onSuccess(memberCommandService.update(member, patch));
     }
@@ -68,11 +74,13 @@ public class MemberController {
     @Operation(summary = "내가 작성한 게시글 목록 조회", description = "내가 작성한 게시글 목록 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/my-boards")
-    public ApiResponse<BoardResponse.BoardListResult> getMyBoards(@AuthenticationMember Member member,
-                                                                  @RequestParam(name = "page") Integer page) {
+    public ApiResponse<BoardResponse.BoardListResult> getMyBoards(
+        @AuthenticationMember Member member,
+        @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        SliceResponse<BoardResponse.BoardItem> boardInfo = boardQueryService.getMyBoards(member, page);
+        SliceResponse<BoardResponse.BoardItem> boardInfo = boardQueryService.getMyBoards(member,
+            page);
 
         return ApiResponse.onSuccess(BoardResponse.toBoardListResult(memberInfo, boardInfo));
     }
@@ -80,11 +88,13 @@ public class MemberController {
     @Operation(summary = "내가 좋아요 한 게시글 목록 조회", description = "내가 좋아요 한 게시글 목록 조회 GET으로 보냅니다.")
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/my-likes")
-    public ApiResponse<BoardResponse.BoardListResult> getMyLikes(@AuthenticationMember Member member,
-                                                                 @RequestParam(name = "page") Integer page) {
+    public ApiResponse<BoardResponse.BoardListResult> getMyLikes(
+        @AuthenticationMember Member member,
+        @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        SliceResponse<BoardResponse.BoardItem> boardInfo = likeQueryService.findMyLikedBoards(member, page);
+        SliceResponse<BoardResponse.BoardItem> boardInfo = likeQueryService.findMyLikedBoards(
+            member, page);
 
         return ApiResponse.onSuccess(BoardResponse.toBoardListResult(memberInfo, boardInfo));
     }
@@ -93,12 +103,21 @@ public class MemberController {
     @Parameter(name = "page", description = "페이징 번호, page, Query String입니다.", example = "0", in = ParameterIn.QUERY)
     @GetMapping("/my-comments")
     public ApiResponse<BoardResponse.BoardListResult> getMyComments(
-            @AuthenticationMember Member member, @RequestParam(name = "page") Integer page) {
+        @AuthenticationMember Member member, @RequestParam(name = "page") Integer page) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        SliceResponse<BoardResponse.BoardItem> boardInfo = commentQueryService.findMyComments(member, page);
+        SliceResponse<BoardResponse.BoardItem> boardInfo = commentQueryService.findMyComments(
+            member, page);
 
         return ApiResponse.onSuccess(BoardResponse.toBoardListResult(memberInfo, boardInfo));
+    }
+
+    @Operation(summary = "Header에 필요한 로그인한 사용자의 정보 조회", description = "로그인한 사용자의 정보 조회 GET으로 보냅니다.")
+    @GetMapping("/members")
+    public ApiResponse<MemberResponse.MemberInfo> getMemberInfo(
+        @AuthenticationMember Member member) {
+
+        return ApiResponse.onSuccess(MemberResponse.toMemberInfo(member));
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -1,5 +1,8 @@
 package com.codez4.meetfolio.domain.member.service;
 
+import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
+import static com.codez4.meetfolio.global.security.Password.ENCODER;
+
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.LoginRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
@@ -13,9 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
-import static com.codez4.meetfolio.global.security.Password.ENCODER;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -26,13 +26,24 @@ public class MemberQueryService {
 
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(
-                () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
         );
     }
 
+    public Member findByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+        );
+    }
+
+    public Member findByMemberName(String name) {
+        return findByEmail(name.concat("@gachon.ac.kr"));
+    }
+
     public Member checkEmailAndPassword(LoginRequest request) {
-        log.debug("email {}" , request.getEmail());
-        Member member = memberRepository.findByEmail(request.getEmail()).orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
+        log.debug("email {}", request.getEmail());
+        Member member = memberRepository.findByEmail(request.getEmail())
+            .orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
         comparePassword(request.getPassword(), member.getPassword());
         return member;
     }

--- a/src/main/java/com/codez4/meetfolio/global/annotation/AuthenticationMemberArgumentResolver.java
+++ b/src/main/java/com/codez4/meetfolio/global/annotation/AuthenticationMemberArgumentResolver.java
@@ -32,14 +32,14 @@ public class AuthenticationMemberArgumentResolver implements HandlerMethodArgume
         WebDataBinderFactory binderFactory
     ) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
 
         // 비로그인 / 로그인 경로 예외
-        if (request.getServletPath().equals("/api")
-            && JwtAuthenticationFilter.extractAccessToken(request) == null) {
+        if ((request.getServletPath().equals("/api") || request.getServletPath()
+            .contains("/api/experiences"))
+            && accessToken == null) {
             return null;
         }
-
-        String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
 
         if (accessToken.isEmpty() || accessToken.isBlank()) {
             throw new ApiException(ErrorStatus._FORBIDDEN);

--- a/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
+++ b/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
-    public static final String[] WHITE_LIST_URL = {
+    private static final String[] WHITE_LIST_URL = {
         // application
         "/api",
         "/api/login",

--- a/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
+++ b/src/main/java/com/codez4/meetfolio/global/config/SecurityConfig.java
@@ -22,20 +22,21 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
-    private static final String[] WHITE_LIST_URL = {
-            // application
-            "/api",
-            "/api/login",
-            "/api/signup",
-            "/api/signup/email",
-            "/api/signup/email/authentication",
+    public static final String[] WHITE_LIST_URL = {
+        // application
+        "/api",
+        "/api/login",
+        "/api/signup",
+        "/api/signup/email",
+        "/api/signup/email/authentication",
+        "/api/experiences/**",
 
-            // swagger
-            "v3/api-docs/**",
-            "/swagger-resources",
-            "/swagger-resources/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html",
+        // swagger
+        "v3/api-docs/**",
+        "/swagger-resources",
+        "/swagger-resources/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
     };
 
     @Bean
@@ -46,20 +47,21 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .exceptionHandling(exceptionHandlingConfigurer ->
-                        exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
-                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry
-                                .requestMatchers("/api/admins/**").hasRole("ADMIN")
-                                .anyRequest()
-                                .authenticated()
-                )
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+            .csrf(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(exceptionHandlingConfigurer ->
+                exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+            .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                authorizationManagerRequestMatcherRegistry
+                    .requestMatchers("/api/admins/**").hasRole("ADMIN")
+                    .anyRequest()
+                    .authenticated()
+            )
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## 요약

- Header에 필요한 로그인 사용자 정보 조회 API
- 자기소개서 작성 및 수정 API 수정
- 활성화 & 공개된 다른 사용자의 자기소개서 조회 API

## 상세 내용

- 다른 사용자의 자기소개서 조회시, 기존 게시글 조회에 id값을 전달하지 않고 있고, repository에서 dto를 통해 받아오고 있어
수정이 많이 일어날거 같아, 일단은 memberName으로 조회하는 식으로 하였습니다.
- RequestBody로 값을 전달받기 위해 Get이 아닌 Post를 사용하였으며, URL은 "/api/coverletters/members"로 하였습니다.

## 질문 및 이외 사항

-

## 이슈 번호

- close #80 
