### PR TITLE
Feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/admin/controller/AdminController.java
@@ -10,6 +10,7 @@ import com.codez4.meetfolio.domain.board.service.BoardQueryService;
 import com.codez4.meetfolio.domain.enums.JobKeyword;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
+import com.codez4.meetfolio.domain.member.service.MemberCommandService;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.exception.ApiException;
@@ -40,6 +41,7 @@ public class AdminController {
     private final AdminQueryService adminQueryService;
     private final AdminCommandService adminCommandService;
     private final MemberQueryService memberQueryService;
+    private final MemberCommandService memberCommandService;
     private final BoardQueryService boardQueryService;
     private final BoardCommandService boardCommandService;
 
@@ -69,7 +71,7 @@ public class AdminController {
     public ApiResponse<String> inactivateMember(@AuthenticationMember Member admin,
                                                 @PathVariable(value = "memberId") Long memberId) {
         Member member = memberQueryService.findById(memberId);
-        adminCommandService.inactivateMember(member);
+        memberCommandService.deleteData(member);
         return ApiResponse.onSuccess("회원 비활성화 성공입니다.");
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/admin/service/AdminCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/admin/service/AdminCommandService.java
@@ -22,20 +22,6 @@ import static com.codez4.meetfolio.domain.admin.dto.DatasetResponse.toDatasetPro
 @Transactional
 public class AdminCommandService {
     private final DatasetRepository datasetRepository;
-    private final ExperienceRepository experienceRepository;
-    private final CoverLetterRepository coverLetterRepository;
-    private final BoardRepository boardRepository;
-    private final LikeRepository likeRepository;
-    private final CommentRepository commentRepository;
-
-    public void inactivateMember(Member member) {
-        commentRepository.deleteByMember(member);
-        likeRepository.deleteByMember(member);
-        boardRepository.deleteByMember(member);
-        experienceRepository.deleteByMember(member);
-        coverLetterRepository.findByMember(member).forEach(CoverLetter::delete);
-        member.setInactive();
-    }
 
     public DatasetResponse.DatasetProc saveDataset(DatasetRequest request) {
         return toDatasetProc(datasetRepository.save(toEntity(request)));

--- a/src/main/java/com/codez4/meetfolio/domain/member/Member.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/Member.java
@@ -73,6 +73,13 @@ public class Member extends BaseTimeEntity {
         this.status = Status.INACTIVE;
     }
 
+    public void withdraw(){
+        setInactive();
+        this.email = "";
+        this.major = "";
+        this.profile = "";
+    }
+
     /**
      * update
      */

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.codez4.meetfolio.domain.member.dto.LoginRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.TokenResponse;
 import com.codez4.meetfolio.domain.member.service.AuthService;
-import com.codez4.meetfolio.domain.member.service.MemberCommandService;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.jwt.JwtAuthenticationFilter;
@@ -27,14 +26,13 @@ import org.springframework.web.bind.annotation.*;
 import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
 
 @Slf4j
-@Tag(name = "로그인/로그아웃 API")
+@Tag(name = "로그인/로그아웃/탈퇴 API")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final MemberQueryService memberQueryService;
-    private final MemberCommandService memberCommandService;
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.codez4.meetfolio.domain.member.dto.LoginRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.dto.TokenResponse;
 import com.codez4.meetfolio.domain.member.service.AuthService;
+import com.codez4.meetfolio.domain.member.service.MemberCommandService;
 import com.codez4.meetfolio.domain.member.service.MemberQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.jwt.JwtAuthenticationFilter;
@@ -33,6 +34,7 @@ import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo
 public class AuthController {
 
     private final MemberQueryService memberQueryService;
+    private final MemberCommandService memberCommandService;
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -42,8 +44,8 @@ public class AuthController {
                                                                         HttpServletResponse response) {
         Member member = memberQueryService.checkEmailAndPassword(request);
         TokenResponse tokenResponse = authService.authorize(member);
-        jwtTokenProvider.setHeaderAccessToken(response, JwtProperties.TOKEN_PREFIX+tokenResponse.getAccessToken());
-        jwtTokenProvider.setHeaderRefreshToken(response, JwtProperties.TOKEN_PREFIX+tokenResponse.getRefreshToken());
+        jwtTokenProvider.setHeaderAccessToken(response, JwtProperties.TOKEN_PREFIX + tokenResponse.getAccessToken());
+        jwtTokenProvider.setHeaderRefreshToken(response, JwtProperties.TOKEN_PREFIX + tokenResponse.getRefreshToken());
         return ResponseEntity.ok().body(ApiResponse.onSuccess(toMemberInfo(member)));
     }
 
@@ -57,10 +59,19 @@ public class AuthController {
             String refreshToken = JwtAuthenticationFilter.extractRefreshToken(request);
             authService.logout(accessToken, refreshToken);
             jwtTokenProvider.setHeaderAccessToken(response, "");
-            jwtTokenProvider.setHeaderRefreshToken(response,"");
+            jwtTokenProvider.setHeaderRefreshToken(response, "");
             ;
         }
         return "redirect:/main";
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴")
+    @DeleteMapping("/withdrawl")
+    public ResponseEntity withDrawl(@AuthenticationMember Member member, HttpServletRequest request) {
+        String accessToken = JwtAuthenticationFilter.extractAccessToken(request);
+        String refreshToken = JwtAuthenticationFilter.extractRefreshToken(request);
+        authService.withdraw(member, accessToken, refreshToken);
+        return ResponseEntity.ok().body("회원탈퇴가 완료되었습니다.");
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/AuthService.java
@@ -43,15 +43,8 @@ public class AuthService {
         redisUtil.setBlackList(accessToken, "accessToken", expiration);
     }
 
-    private Cookie findCookie(HttpServletRequest request, String cookieName){
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null){
-            return null;
-        }
-
-        return Arrays.stream(cookies)
-                .filter(cookie -> cookie.getName().equals(cookieName))
-                .findFirst()
-                .orElse(null);
+    public void withdraw(Member member, String accessToken, String refreshToken){
+        member.withdraw();
+        logout(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
@@ -1,9 +1,17 @@
 package com.codez4.meetfolio.domain.member.service;
 
+import com.codez4.meetfolio.domain.board.repository.BoardRepository;
+import com.codez4.meetfolio.domain.comment.repository.CommentRepository;
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
+import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.member.repository.MemberRepository;
+import com.codez4.meetfolio.global.jwt.JwtTokenProvider;
+import com.codez4.meetfolio.global.utils.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final ExperienceRepository experienceRepository;
+    private final CoverLetterRepository coverLetterRepository;
+    private final BoardRepository boardRepository;
+    private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
 
     public Member save(MemberRequest.Post post) {
         return memberRepository.save(MemberRequest.toEntity(post));
@@ -24,10 +39,18 @@ public class MemberCommandService {
         return MemberResponse.toMemberProc(member);
     }
 
-
     public MemberResponse.MemberProc update(Member member, MemberRequest.Patch patch) {
         member.update(patch);
         return MemberResponse.toMemberProc(member);
+    }
+
+    public void deleteData(Member member) {
+        commentRepository.deleteByMember(member);
+        likeRepository.deleteByMember(member);
+        boardRepository.deleteByMember(member);
+        experienceRepository.deleteByMember(member);
+        coverLetterRepository.findByMember(member).forEach(CoverLetter::delete);
+        member.setInactive();
     }
 
 }

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberQueryService.java
@@ -1,8 +1,11 @@
 package com.codez4.meetfolio.domain.member.service;
 
-import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
-import static com.codez4.meetfolio.global.security.Password.ENCODER;
-
+import com.codez4.meetfolio.domain.board.repository.BoardRepository;
+import com.codez4.meetfolio.domain.comment.repository.CommentRepository;
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
+import com.codez4.meetfolio.domain.experience.repository.ExperienceRepository;
+import com.codez4.meetfolio.domain.like.repository.LikeRepository;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.LoginRequest;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
@@ -16,6 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.codez4.meetfolio.domain.member.dto.MemberResponse.toMemberInfo;
+import static com.codez4.meetfolio.global.security.Password.ENCODER;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,15 +30,16 @@ public class MemberQueryService {
 
     private final MemberRepository memberRepository;
 
+
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(
-            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+                () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
         );
     }
 
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email).orElseThrow(
-            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
+                () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND)
         );
     }
 
@@ -43,7 +50,7 @@ public class MemberQueryService {
     public Member checkEmailAndPassword(LoginRequest request) {
         log.debug("email {}", request.getEmail());
         Member member = memberRepository.findByEmail(request.getEmail())
-            .orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND));
         comparePassword(request.getPassword(), member.getPassword());
         return member;
     }
@@ -53,6 +60,7 @@ public class MemberQueryService {
             throw new ApiException(ErrorStatus._INVALID_PASSWORD);
         }
     }
+
 
     public MemberInfo getMemberInfo(Long memberId) {
         return toMemberInfo(findById(memberId));


### PR DESCRIPTION
## 요약

- 회원 탈퇴 API 구현

## 상세 내용

- 회원 탈퇴 API 구현
  - 자소서 데이터 보존을 위해, member을 삭제하지 않고 개인 정보및 저장된 데이터들을 삭제하였습니다.

## 질문 및 이외 사항

-

## 이슈 번호

- close #
