### PR TITLE
:fire: Fix: GPT Feedback 데이터 저장에 따른 데이터 자료형 변환

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/dataset/Dataset.java
+++ b/src/main/java/com/codez4/meetfolio/domain/dataset/Dataset.java
@@ -16,14 +16,14 @@ public class Dataset extends BaseTimeEntity {
     @Column(name = "dataset_id",nullable = false)
     private Long id;
 
-    @Column(name = "job")
+    @Column(name = "job", nullable = false)
     @Enumerated(value = EnumType.STRING)
     private JobKeyword jobKeyword;
 
-    @Column(nullable = false)
+    @Column
     private String url;
 
-    @Column(nullable = false)
+    @Column
     private String domain;
   
     @Column(length = 1000, nullable = false)

--- a/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
+++ b/src/main/java/com/codez4/meetfolio/domain/feedback/Feedback.java
@@ -23,7 +23,7 @@ public class Feedback extends BaseTimeEntity {
     @JoinColumn(name = "cover_letter_id", nullable = false)
     private CoverLetter coverLetter;
 
-    @Column(name = "spell_check", length = 1000, nullable = false)
+    @Column(name = "spell_check", length = 1000)
     private String spellCheck;
 
     @Column(length = 1000, nullable = false)
@@ -38,7 +38,7 @@ public class Feedback extends BaseTimeEntity {
     @Column(name = "recommend_question_3", nullable = false)
     private String recommendQuestion3;
 
-    @Column(nullable = false)
+    @Column
     private Integer satisfaction;
 
     @Column(nullable = false)


### PR DESCRIPTION
Related: #97

## 요약

- GPT Feedback 데이터 저장에 따른 데이터 자료형 변환

## 상세 내용

- 다른 엔티티에 length=1000으로 수정되어 있어서, 다른 부분 nullable=False만 수정하였습니다.

## 질문 및 이외 사항

- dev랑 prod 환경에 한 번 데이터셋 적용해야 할 것 같습니다.

## 이슈 번호

- close #97 
