### PR TITLE
Feat: 카카오페이 프론트 연동 API 구현

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/controller/PaymentController.java
@@ -9,6 +9,8 @@ import com.codez4.meetfolio.domain.payment.service.PaymentQueryService;
 import com.codez4.meetfolio.global.annotation.AuthenticationMember;
 import com.codez4.meetfolio.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,23 @@ import org.springframework.web.bind.annotation.*;
 public class PaymentController {
     private final PaymentQueryService paymentQueryService;
     private final PaymentCommandService paymentCommandService;
+
+    @Operation(summary = "카카오 페이 요청 정보 등록", description = "카카오 페이 결제 요청 정보를 저장합니다.")
+    @PostMapping("/payments/ready")
+    public ApiResponse<PaymentResponse.PaymentProc> saveReadyPayment(@AuthenticationMember Member member,
+                                                                    @Valid @RequestBody PaymentRequest.ReadyRequest request){
+        return ApiResponse.onSuccess(paymentCommandService.saveReadyPayment(member, request));
+
+    }
+
+    @Operation(summary = "카카오 페이 승인 정보 등록", description = "카카오 페이 승인 정보 저장 및 포인트를 충전합니다.")
+    @PostMapping("/payments/approve/{paymentId}")
+    @Parameter(name = "paymentId", description = "결제 id, Path Variable 입니다.", required = true, in = ParameterIn.PATH)
+    public ApiResponse<PaymentResponse.PaymentProc> saveApprovePayment(@AuthenticationMember Member member,
+                                                                      @Valid @PathVariable Long paymentId) {
+        return ApiResponse.onSuccess(paymentCommandService.saveApprovePayment(member, paymentQueryService.findById(paymentId)));
+
+    }
 
     @Operation(summary = "포인트 충전 - 카카오 페이 연결", description = "포인트 충전 요청 시 카카오 페이 redirect url을 반환합니다.")
     @PostMapping("/payments/request")

--- a/src/main/java/com/codez4/meetfolio/domain/payment/dto/KakaoPayRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/dto/KakaoPayRequest.java
@@ -11,6 +11,7 @@ public class KakaoPayRequest {
         private String url;
         private LinkedMultiValueMap<String, String> map;
 
+
     public static KakaoPayRequest toReadyRequest(Long paymentId, PaymentRequest.ChargeRequest chargeRequest) {
         String MEETFOLIO_HOST = "http://34.64.177.41:9090";
         String KAKAO_PAY_READY_URL = "https://kapi.kakao.com/v1/payment/ready";

--- a/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentRequest.java
@@ -10,6 +10,20 @@ import lombok.Getter;
 
 public class PaymentRequest {
 
+    @Schema(description = "카카오 페이 연결 정보 저장 dto")
+    @Getter
+    public static class ReadyRequest {
+
+        @Schema(description = "충전할 포인트")
+        private int point;
+
+        @Schema(description = "결제할 금액")
+        private int payment;
+
+        @Schema(description = "카카오 페이 결제 id")
+        private String tid;
+    }
+
     @Schema(description = "포인트 충전 요청 dto")
     @Getter
     public static class ChargeRequest {

--- a/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentResponse.java
@@ -116,10 +116,26 @@ public class PaymentResponse {
         @Schema(description = "상품명")
         private String itemName;
         @Schema(description = "결제 요청 시간")
-        private String createdAt;
+        private String readyAt;
         @Schema(description = "결제 응답 시간")
         private String approveAt;
 
+    }
+
+    @Schema(description = "카카오 페이 정보 완료 응답 dto")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class  PaymentProc{
+        @Schema(description = "결제 내역 ID")
+        private Long paymentId;
+        @Schema(description = "카카오 페이 결제 ID")
+        private String tid;
+        @Schema(description = "결제 요청 시간")
+        private LocalDateTime readyAt;
+        @Schema(description = "결제 응답 시간")
+        private LocalDateTime approveAt;
     }
 
     public static PaymentResult toPaymentResult(Member member , Page<Point> points, List<PaymentItem> paymentList ){
@@ -164,8 +180,17 @@ public class PaymentResponse {
                 .paymentId(paymentId)
                 .itemName(response.getItem_name())
                 .amount(response.getAmount())
-                .createdAt(response.getCreated_at())
+                .readyAt(response.getCreated_at())
                 .approveAt(response.getApproved_at())
+                .build();
+    }
+
+    public static PaymentProc toPaymentProc(Payment payment){
+        return PaymentProc.builder()
+                .paymentId(payment.getId())
+                .tid(payment.getKakaoPayId())
+                .readyAt(payment.getCreatedAt())
+                .approveAt(payment.getUpdatedAt())
                 .build();
     }
 


### PR DESCRIPTION
## 요약

- 카카오 페이 리다이렉트 이슈로 인하여 프론트 연동 준비를 위한 API 생성

## 상세 내용

- 카카오 페이 요청 정보 저장 API
- 카카오 페이 승인 정보 저장 및 포인트 충전 API

## 질문 및 이외 사항

-

## 이슈 번호

- close #
