### PR TITLE
Refactor: 카카오 페이 승인 정보 등록 로직 수정

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/payment/Payment.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/Payment.java
@@ -31,11 +31,11 @@ public class Payment extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
 
-    @Column(name = "kakao_pay_id")
-    private String kakaoPayId;
+    @Column(name = "tid")
+    private String tid;
 
-    public void updateKakaoPayId(String kakaoPayId){
-        this.kakaoPayId = kakaoPayId;
+    public void updateTid(String tid){
+        this.tid = tid;
     }
 
     public void updateStatus (PaymentStatus paymentStatus){

--- a/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentRequest.java
@@ -35,6 +35,14 @@ public class PaymentRequest {
         private int payment;
     }
 
+    @Schema(description = "카카오페이 승인 정보 저장 dto")
+    @Getter
+    public static class ApproveRequest {
+
+        @Schema(description = "충전할 포인트")
+        private String tid;
+    }
+
 
     /*
         payment 생성 dto
@@ -47,7 +55,7 @@ public class PaymentRequest {
         private int point;
         private Member member;
         private PaymentStatus paymentStatus;
-        private String kakaoPayId;
+        private String tid;
 
     }
 
@@ -57,7 +65,7 @@ public class PaymentRequest {
                 .point(post.point)
                 .member(post.member)
                 .paymentStatus(post.paymentStatus)
-                .kakaoPayId(post.kakaoPayId)
+                .tid(post.tid)
                 .build();
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/dto/PaymentResponse.java
@@ -188,7 +188,7 @@ public class PaymentResponse {
     public static PaymentProc toPaymentProc(Payment payment){
         return PaymentProc.builder()
                 .paymentId(payment.getId())
-                .tid(payment.getKakaoPayId())
+                .tid(payment.getTid())
                 .readyAt(payment.getCreatedAt())
                 .approveAt(payment.getUpdatedAt())
                 .build();

--- a/src/main/java/com/codez4/meetfolio/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/repository/PaymentRepository.java
@@ -10,11 +10,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Page<Payment> findByMember_AuthorityAndPaymentStatusIs(Authority authority, PaymentStatus paymentStatus, Pageable pageable);
 
-    Payment findTop1ByMemberOrderByIdDesc(Member member);
+    Optional<Payment> findTop1ByMemberAndPaymentStatusOrderByIdDesc(Member member, PaymentStatus paymentStatus);
+
+    Optional<Payment> findByMemberAndTidAndPaymentStatus(Member member, String tid, PaymentStatus paymentStatus);
 
     @Query("SELECT IFNULL(SUM(p.payment),0) FROM Payment p WHERE p.paymentStatus = 'APPROVE'")
     long queryGetTotalSales();

--- a/src/main/java/com/codez4/meetfolio/domain/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/service/PaymentCommandService.java
@@ -38,14 +38,13 @@ public class PaymentCommandService {
                 .payment(request.getPayment())
                 .member(member)
                 .paymentStatus(PaymentStatus.READY)
-                .kakaoPayId(request.getTid())
+                .tid(request.getTid())
                 .build();
         Payment payment = post(paymentPost);
         return toPaymentProc(payment);
     }
 
-    public PaymentProc saveApprovePayment(Member member) {
-        Payment payment = paymentRepository.findTop1ByMemberOrderByIdDesc(member);
+    public PaymentProc saveApprovePayment(Member member, Payment payment) {
         payment.updateStatus(PaymentStatus.APPROVE);
         int totalPoint = member.getPoint() - payment.getPoint();
         PointRequest.Post pointPost = PointRequest.Post.builder()
@@ -65,13 +64,13 @@ public class PaymentCommandService {
                 .point(request.getPoint())
                 .payment(request.getPayment())
                 .member(member)
-                .kakaoPayId(null)
+                .tid(null)
                 .paymentStatus(null)
                 .build();
         Payment payment = post(paymentPost);
         KakaoPayResponse.Ready response = kakaoPayService.getRedirectUrl(payment.getId(), request);
 
-        payment.updateKakaoPayId(response.getTid());
+        payment.updateTid(response.getTid());
         payment.updateStatus(PaymentStatus.READY);
         return toPaymentReady(payment.getId(), response);
     }

--- a/src/main/java/com/codez4/meetfolio/domain/payment/service/PaymentQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/service/PaymentQueryService.java
@@ -39,7 +39,7 @@ public class PaymentQueryService {
     }
 
     public Payment getApprovePayment(Member member, String tid){
-        Payment payment = paymentRepository.findByMemberAndTidAndPaymentStatus(member, tid, PaymentStatus.APPROVE).orElseThrow(() -> new ApiException(ErrorStatus._PAYMENT_NOT_FOUND));
+        Payment payment = paymentRepository.findByMemberAndTidAndPaymentStatus(member, tid, PaymentStatus.READY).orElseThrow(() -> new ApiException(ErrorStatus._PAYMENT_NOT_FOUND));
         return payment;
     }
 

--- a/src/main/java/com/codez4/meetfolio/domain/payment/service/PaymentQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/payment/service/PaymentQueryService.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.payment.service;
 
+import com.codez4.meetfolio.domain.enums.PaymentStatus;
 import com.codez4.meetfolio.domain.enums.PointType;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.payment.Payment;
@@ -31,10 +32,17 @@ public class PaymentQueryService {
         return paymentRepository.findById(paymentId).orElseThrow(() -> new ApiException(ErrorStatus._PAYMENT_NOT_FOUND));
     }
 
-    public PaymentResponse.PaymentProc getReadyPayment(Member member){
-        Payment payment = paymentRepository.findTop1ByMemberOrderByIdDesc(member);
-        return toPaymentProc(payment);
+    public Payment getReadyPayment(Member member){
+        Payment payment = paymentRepository.findTop1ByMemberAndPaymentStatusOrderByIdDesc(member,PaymentStatus.READY).orElseThrow(() -> new ApiException(ErrorStatus._PAYMENT_NOT_FOUND));;
+        return payment;
+
     }
+
+    public Payment getApprovePayment(Member member, String tid){
+        Payment payment = paymentRepository.findByMemberAndTidAndPaymentStatus(member, tid, PaymentStatus.APPROVE).orElseThrow(() -> new ApiException(ErrorStatus._PAYMENT_NOT_FOUND));
+        return payment;
+    }
+
 
     public PaymentResponse.PaymentResult getMyPaymentList(int page, Member member) {
         PageRequest pageRequest = PageRequest.of(page, 9, Sort.by("id").descending());


### PR DESCRIPTION
## 요약

- 카카오 페이 승인 정보 등록 로직 수정

## 상세 내용

- Hotfix 였던 로그인 사용자의 정보로 결제 내역을 가져오는 로직에서 추가로 tid와 결제 상태로 결제내역을 가져오도록 로직을 수정하였습니다.

## 질문 및 이외 사항

-

## 이슈 번호

- close #
