### PR TITLE
Hotfix: 사용자 개인정보 수정 로직 수정

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/member/Member.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/Member.java
@@ -83,11 +83,14 @@ public class Member extends BaseTimeEntity {
     /**
      * update
      */
-    public void update(MemberRequest.Patch request) {
-        this.password = Password.encrypt(request.getPassword(), ENCODER);
+    public void updateInfo(MemberRequest.Patch request) {
         this.major = request.getMajor();
         this.grade = Grade.convert(request.getGrade());
         this.jobKeyword = JobKeyword.convert(request.getJobKeyword());
+    }
+
+    public void updatePassword(String password){
+        this.password = Password.encrypt(password, ENCODER);
     }
       
     public void setPoint(int point){

--- a/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/member/service/MemberCommandService.java
@@ -40,7 +40,10 @@ public class MemberCommandService {
     }
 
     public MemberResponse.MemberProc update(Member member, MemberRequest.Patch patch) {
-        member.update(patch);
+        if(patch.getPassword()!=null){
+            member.updatePassword(patch.getPassword());
+        }
+        member.updateInfo(patch);
         return MemberResponse.toMemberProc(member);
     }
 


### PR DESCRIPTION
## 요약

- 사용자 개인정보 수정 로직 수정

## 상세 내용

- 사용자 개인정보 수정시, 변경할 비밀번호를 입력하지 않으면 수정이 안 되는 오류 수정
- 비밀번호 값이 null일 때와 아닐 때의 분기 처리로 수정

## 질문 및 이외 사항

-

## 이슈 번호

- close #
