### PR TITLE
Hotfix : 댓글 삭제 시 게시물의 댓글 수 차감 로직 수정

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/controller/CommentController.java
@@ -63,7 +63,6 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     public ApiResponse<CommentResponse.CommentProc> deleteComment(
         @PathVariable(name = "commentId") Long commentId) {
-
         return ApiResponse.onSuccess(commentCommandService.delete(commentId));
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/controller/CommentController.java
@@ -52,10 +52,10 @@ public class CommentController {
     @Operation(summary = "댓글 수정 요청", description = "댓글 수정 요청을 PATCH로 보냅니다.")
     @Parameter(name = "commentId", description = "댓글 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @PatchMapping("/{commentId}")
-    public ApiResponse<CommentResponse.CommentProc> updateComment(@RequestBody String content,
+    public ApiResponse<CommentResponse.CommentProc> updateComment(@RequestBody CommentRequest.PATCH request,
         @PathVariable(name = "commentId") Long commentId) {
 
-        return ApiResponse.onSuccess(commentCommandService.update(content, commentId));
+        return ApiResponse.onSuccess(commentCommandService.update(request.getContent(), commentId));
     }
 
     @Operation(summary = "댓글 삭제 요청", description = "댓글 삭제 요청을 DELETE로 보냅니다.")

--- a/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentRequest.java
@@ -16,4 +16,13 @@ public class CommentRequest {
         private Long parentId;
     }
 
+    @Schema(description = "게시글 댓글 수정 요청 DTO")
+    @Getter
+    public static class PATCH {
+
+        @Schema(description = "댓글 내용")
+        private String content;
+
+    }
+
 }

--- a/src/main/java/com/codez4/meetfolio/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/service/CommentCommandService.java
@@ -66,7 +66,8 @@ public class CommentCommandService {
 
     public CommentResponse.CommentProc delete(Long commentId) {
         Comment comment = commentQueryService.findById(commentId);
-        comment.getBoard().changeComment(false);
+        Board board  = comment.getBoard();
+        board.changeComment(false);
         commentRepository.deleteById(commentId);
         return CommentResponse.toCommentProc(commentId);
     }


### PR DESCRIPTION
## 요약

- 댓글 삭제 시, 게시물의 댓글 수가 차감되지 않는 버그 발생하여 로직 수정

## 상세 내용

- lazy fetch 전략 때문에 board 객체를 바로 받아오지 못하여 발생하는 버그로 추정..

## 질문 및 이외 사항

-

## 이슈 번호

- close #
