### PR TITLE
Fix: 타 사용자 자소서 조회 시 포인트 사용 로직 수정

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -53,7 +53,7 @@ public class CoverLetterController {
                                                          @PathVariable(name = "coverLetterId") Long coverLetterId) {
 
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
-        CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(coverLetterId);
+        CoverLetterInfo coverLetterInfo = coverLetterQueryService.getCoverLetterInfo(member, coverLetterId);
         FeedbackInfo feedbackInfo = feedbackQueryService.getFeedbackInfo(coverLetterId);
         AnalysisInfo analysisInfo = analysisQueryService.getAnalysisInfo(coverLetterId);
         CoverLetterResult coverLetterResult = CoverLetterResponse.toCoverLetterResult(memberInfo,

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -45,9 +45,12 @@ public class CoverLetterResponse {
 
         @Schema(description = "지원 직무")
         private String jobKeyword;
+
+        @Schema(description = "타 사용자 자소서 조회할 때, 포인트 사용 여부")
+        private Boolean isPaid;
     }
 
-    public static CoverLetterInfo toCoverLetterInfo(CoverLetter coverLetter) {
+    public static CoverLetterInfo toCoverLetterInfo(CoverLetter coverLetter, Boolean isPaid) {
 
         return CoverLetterInfo.builder()
                 .coverLetterId(coverLetter.getId())
@@ -57,6 +60,7 @@ public class CoverLetterResponse {
                 .keyword1(coverLetter.getKeyword1())
                 .keyword2(coverLetter.getKeyword2())
                 .jobKeyword(coverLetter.getJobKeyword() != null ? coverLetter.getJobKeyword().getDescription() : null)
+                .isPaid(isPaid)
                 .build();
 
     }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
@@ -5,26 +5,37 @@ import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse;
 import com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.CoverLetterInfo;
 import com.codez4.meetfolio.domain.coverLetter.repository.CoverLetterRepository;
 import com.codez4.meetfolio.domain.member.Member;
+import com.codez4.meetfolio.domain.point.repository.PointRepository;
 import com.codez4.meetfolio.global.exception.ApiException;
 import com.codez4.meetfolio.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CoverLetterQueryService {
 
     private final CoverLetterRepository coverLetterRepository;
+    private final PointRepository pointRepository;
 
-    public CoverLetterInfo getCoverLetterInfo(Long coverLetterId) {
-
+    public CoverLetterInfo getCoverLetterInfo(Member member, Long coverLetterId) {
         CoverLetter coverLetter = findById(coverLetterId);
-        return CoverLetterResponse.toCoverLetterInfo(coverLetter);
+        Boolean isPaid;
+        Member coverletterMember = coverLetter.getMember();
+        if(member != coverletterMember) {
+            isPaid = pointRepository.getPointByCoverLetterAndMember(coverLetter, member).isPresent();
+        }
+        else {
+            isPaid = null;
+        }
+        return CoverLetterResponse.toCoverLetterInfo(coverLetter,isPaid);
     }
 
     public CoverLetter findById(Long coverLetterId) {

--- a/src/main/java/com/codez4/meetfolio/domain/point/Point.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/Point.java
@@ -1,6 +1,7 @@
 package com.codez4.meetfolio.domain.point;
 
 import com.codez4.meetfolio.domain.common.BaseTimeEntity;
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.enums.PointType;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.payment.Payment;
@@ -35,4 +36,8 @@ public class Point extends BaseTimeEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private PointType pointType;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coverletter_id", nullable = true)
+    private CoverLetter coverLetter;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/point/dto/PointRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/dto/PointRequest.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.point.dto;
 
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.enums.PointType;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.payment.Payment;
@@ -21,6 +22,7 @@ public class PointRequest {
 
         @Schema(description = "사용할 포인트")
         int point;
+
     }
 
     /*
@@ -35,6 +37,7 @@ public class PointRequest {
         int totalPoint;
         Member member;
         Payment payment;
+        CoverLetter coverLetter;
     }
 
     public static Point toEntity(Post post){
@@ -44,6 +47,7 @@ public class PointRequest {
                 .totalPoint(post.getTotalPoint())
                 .member(post.getMember())
                 .payment(post.payment)
+                .coverLetter(post.coverLetter)
                 .build();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/repository/PointRepository.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.point.repository;
 
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.enums.PointType;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.payment.Payment;
@@ -24,5 +25,8 @@ public interface PointRepository extends JpaRepository<Point, Long> {
 
     @Query("SELECT IFNULL(MAX(POINTSUM.POINT), 0) FROM (SELECT DATE_FORMAT(p.createdAt, '%Y-%c') AS MONTH, sum(p.point) AS POINT FROM Point p WHERE p.pointType != :type GROUP BY MONTH) AS POINTSUM WHERE POINTSUM.MONTH =:month")
     long queryGetAllPointSum(PointType type, String month);
+
+    Optional<Point> getPointByCoverLetterAndMember(CoverLetter coverLetter, Member member);
+
 
 }


### PR DESCRIPTION
## 요약

- 타 사용자 자소서 조회 시 포인트 사용 로직 수정

## 상세 내용

- Point 테이블에 coverletter_id 외래키 추가
  - 포인트 사용 시, 포인트 사용 타입에 따라 coverletter_id 삽입
- 자소서 상세 조회 시
- 내 자소서면 response dto의 isPaid = null
- 타 사용자의 자소서일 경우 포인트 사용 여부에 따라 true/false 반환

## 질문 및 이외 사항

-

## 이슈 번호

- close #
