### PR TITLE
Refactor: 댓글 대댓글 계층 구조 적용

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/comment/Comment.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/Comment.java
@@ -39,6 +39,15 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parentComment", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Comment> children = new ArrayList<>();
 
+    @Column(nullable = false)
+    private int ref;
+
+    @Column(nullable = false)
+    private int refOrder;
+
+    @Column(nullable = false)
+    private int step;
+
     /**
      * update
      */

--- a/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentResponse.java
@@ -80,13 +80,7 @@ public class CommentResponse {
     }
 
 
-    public static CommentResult toCommentResult(Slice<Comment> comments) {
-
-        // 부모 댓글만 반환하기 (자식 댓글은 부모 댓글 안에 담아서 전달)
-        List<CommentItem> commentItems = comments.stream()
-                .filter(comment -> comment.getParentComment() == null)
-                .map(CommentResponse::toCommentItem)
-                .toList();
+    public static CommentResult toCommentResult(List<CommentItem> commentItems, Slice<Comment> comments) {
 
         return CommentResult.builder()
                 .commentItems(commentItems)
@@ -177,7 +171,7 @@ public class CommentResponse {
                 .build();
     }
 
-    public static CommentItem toCommentItem(Comment comment) {
+    public static CommentItem toCommentItem(Comment comment, List<CommentItem> childComments) {
 
         Member member = comment.getMember();
         long sinceCreation = TimeUtils.getSinceCreation(comment.getCreatedAt());
@@ -188,18 +182,18 @@ public class CommentResponse {
                 .memberName(member.getEmail().split("@")[0])
                 .profile(member.getProfile().name())
                 .sinceCreation(sinceCreation)
-                .childComments(getChildList(comment))
+                .childComments(childComments)
                 .build();
     }
 
-    private static List<CommentItem> getChildList(Comment comment) {
-
-        return Optional.ofNullable(comment.getChildren())
-                .orElse(new ArrayList<>())
-                .stream()
-                .map(CommentResponse::toCommentItem)
-                .toList();
-    }
+//    private static List<CommentItem> getChildList(Comment comment) {
+//
+//        return Optional.ofNullable(comment.getChildren())
+//                .orElse(new ArrayList<>())
+//                .stream()
+//                .map(CommentResponse::toCommentItem)
+//                .toList();
+//    }
 
     @Schema(description = "댓글 처리 응답 DTO")
     @Builder

--- a/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentResponse.java
@@ -84,16 +84,16 @@ public class CommentResponse {
 
         // 부모 댓글만 반환하기 (자식 댓글은 부모 댓글 안에 담아서 전달)
         List<CommentItem> commentItems = comments.stream()
-            .filter(comment -> comment.getParentComment() == null)
-            .map(CommentResponse::toCommentItem)
-            .toList();
+                .filter(comment -> comment.getParentComment() == null)
+                .map(CommentResponse::toCommentItem)
+                .toList();
 
         return CommentResult.builder()
-            .commentItems(commentItems)
-            .hasNext(comments.hasNext())
-            .isFirst(comments.isFirst())
-            .isLast(comments.isLast())
-            .build();
+                .commentItems(commentItems)
+                .hasNext(comments.hasNext())
+                .isFirst(comments.isFirst())
+                .isLast(comments.isLast())
+                .build();
     }
 
     public static MyCommentResult toMyCommentResult(MemberResponse.MemberInfo memberInfo, Page<MyCommentItem> comments) {
@@ -103,7 +103,7 @@ public class CommentResponse {
                 .build();
     }
 
-    public static MyCommentList toMyCommentList(Page<MyCommentItem> comments){
+    public static MyCommentList toMyCommentList(Page<MyCommentItem> comments) {
         List<MyCommentItem> commentItems = comments.stream().toList();
         return MyCommentList.builder()
                 .commentInfo(commentItems)
@@ -166,7 +166,7 @@ public class CommentResponse {
 
     }
 
-    public static MyCommentItem toMyCommentItem(Comment comment){
+    public static MyCommentItem toMyCommentItem(Comment comment) {
         Board board = comment.getBoard();
         return MyCommentItem.builder()
                 .commentId(comment.getId())
@@ -183,22 +183,22 @@ public class CommentResponse {
         long sinceCreation = TimeUtils.getSinceCreation(comment.getCreatedAt());
 
         return CommentItem.builder()
-            .commentId(comment.getId())
-            .content(comment.getContent())
-            .memberName(member.getEmail().split("@")[0])
-            .profile(member.getProfile().name())
-            .sinceCreation(sinceCreation)
-            .childComments(getChildList(comment))
-            .build();
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .memberName(member.getEmail().split("@")[0])
+                .profile(member.getProfile().name())
+                .sinceCreation(sinceCreation)
+                .childComments(getChildList(comment))
+                .build();
     }
 
     private static List<CommentItem> getChildList(Comment comment) {
 
         return Optional.ofNullable(comment.getChildren())
-            .orElse(new ArrayList<>())
-            .stream()
-            .map(CommentResponse::toCommentItem)
-            .toList();
+                .orElse(new ArrayList<>())
+                .stream()
+                .map(CommentResponse::toCommentItem)
+                .toList();
     }
 
     @Schema(description = "댓글 처리 응답 DTO")
@@ -218,20 +218,23 @@ public class CommentResponse {
     public static CommentProc toCommentProc(Long commentId) {
 
         return CommentProc.builder()
-            .commentId(commentId)
-            .createdAt(LocalDateTime.now())
-            .build();
+                .commentId(commentId)
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 
-    public static Comment toEntity(Member member, Board board, String content,
-        Comment parentComment) {
+    public static Comment toEntity(Member member, Board board, String content,Comment parentComment, int ref, int refOrder, int
+            step) {
 
         return Comment.builder()
-            .member(member)
-            .board(board)
-            .content(content)
-            .parentComment(parentComment)
-            .build();
+                .member(member)
+                .board(board)
+                .content(content)
+                .parentComment(parentComment)
+                .ref(ref)
+                .refOrder(refOrder)
+                .step(step)
+                .build();
     }
 
 

--- a/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/dto/CommentResponse.java
@@ -186,15 +186,6 @@ public class CommentResponse {
                 .build();
     }
 
-//    private static List<CommentItem> getChildList(Comment comment) {
-//
-//        return Optional.ofNullable(comment.getChildren())
-//                .orElse(new ArrayList<>())
-//                .stream()
-//                .map(CommentResponse::toCommentItem)
-//                .toList();
-//    }
-
     @Schema(description = "댓글 처리 응답 DTO")
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -35,4 +37,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c.step FROM Comment c WHERE c.board = :board and c.id = :parent")
     int getStep(Board board, Long parent);
+
+    List<Comment> findAllByBoard_IdAndRef(Long boardId, int ref);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.comment.repository;
 
+import com.codez4.meetfolio.domain.board.Board;
 import com.codez4.meetfolio.domain.comment.Comment;
 import com.codez4.meetfolio.domain.member.Member;
 import org.springframework.data.domain.Page;
@@ -22,4 +23,16 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c JOIN FETCH c.member where c.board.id = :boardId")
     Slice<Comment> findByBoardFetchJoinMember(@Param("boardId") Long boardId,
         PageRequest pageRequest);
+
+    @Query("SELECT c.ref FROM Comment c WHERE c.board = :board and c.id = :parent")
+    int getRefNumOfParent(Board board, Long parent);
+
+    @Query("SELECT IFNULL(MAX(c.ref), 0) FROM Comment c WHERE c.board = :board")
+    int getRefNum(Board board);
+
+    @Query("SELECT IFNULL(MAX(c.refOrder), 0) FROM Comment c WHERE c.board = :board and c.ref = :ref")
+    int getRefOrder(Board board, Integer ref);
+
+    @Query("SELECT c.step FROM Comment c WHERE c.board = :board and c.id = :parent")
+    int getStep(Board board, Long parent);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/comment/service/CommentCommandService.java
@@ -42,19 +42,19 @@ public class CommentCommandService {
 
         if (parentId != null) {
             Comment parentComment = getParentComment(parentId);
-            return CommentResponse.toEntity(member, board, content, parentComment);
+            int ref = commentRepository.getRefNumOfParent(board, parentId);
+            int refOrder = commentRepository.getRefOrder(board, ref);
+            int step = commentRepository.getStep(board, parentId);
+            return CommentResponse.toEntity(member, board, content, parentComment, ref, refOrder+1, step+1);
         }
-        return CommentResponse.toEntity(member, board, content, null);
+        else {
+            int ref = commentRepository.getRefNum(board);
+            return CommentResponse.toEntity(member, board, content, null, ref + 1, 0, 0);
+        }
     }
 
     public Comment getParentComment(Long parentId) {
-        Comment parentComment = commentQueryService.findById(parentId);
-
-        // 부모의 댓글이 있는 경우 -> 에러 발생 (대댓글까지만 가능)
-        if (parentComment.getParentComment() != null) {
-            throw new ApiException(ErrorStatus._COMMENT_OVER_DEPTH_);
-        }
-        return parentComment;
+        return commentQueryService.findById(parentId);
     }
 
     public CommentResponse.CommentProc update(String content, Long commentId) {


### PR DESCRIPTION
## 요약

- 댓글 대댓글 계층 구조 적용

## 상세 내용

- 대댓글에도 답글을 남길 수 있도록 요구사항이 변동되어 이에 따른 로직 수정
- comment 테이블에 ref(댓글 그룹), ref_order(댓글 그룹 안에서의 댓글 순서), step(댓글 계층) 속성 추가
- db 변경에 따른 댓글 작성 및 조회 로직 수정

## 질문 및 이외 사항

-

## 이슈 번호

- close #
