### PR TITLE
Feat: 타 사용자 조회 시, 공유한 사용자에게 포인트 전달

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/enums/PointType.java
+++ b/src/main/java/com/codez4/meetfolio/domain/enums/PointType.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PointType {
     USE_COVER_LETTER("자소서 조회"),
+    SHARE_COVER_LETTER("자소서 공유"),
     USE_AI_ANALYSIS("AI 직무 역량 분석"),
     CHARGE("충전");
     private final String description;

--- a/src/main/java/com/codez4/meetfolio/domain/point/Point.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/Point.java
@@ -37,7 +37,7 @@ public class Point extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PointType pointType;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coverletter_id", nullable = true)
     private CoverLetter coverLetter;
 }

--- a/src/main/java/com/codez4/meetfolio/domain/point/dto/PointRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/dto/PointRequest.java
@@ -12,9 +12,10 @@ import lombok.Builder;
 import lombok.Getter;
 
 public class PointRequest {
+
     @Schema(description = "포인트 사용 요청 dto")
     @Getter
-    public static class PointUseRequest{
+    public static class PointUseRequest {
 
         @Schema(description = "포인트 사용 타입, USE_COVER_LETTER/USE_AI_ANALYSIS")
         @EnumValid(enumClass = PointType.class)
@@ -31,7 +32,8 @@ public class PointRequest {
     @Getter
     @AllArgsConstructor
     @Builder
-    public static class Post{
+    public static class Post {
+
         int point;
         PointType pointType;
         int totalPoint;
@@ -40,7 +42,7 @@ public class PointRequest {
         CoverLetter coverLetter;
     }
 
-    public static Point toEntity(Post post){
+    public static Point toEntity(Post post) {
         return Point.builder()
                 .point(post.getPoint())
                 .pointType(post.getPointType())
@@ -48,6 +50,18 @@ public class PointRequest {
                 .member(post.getMember())
                 .payment(post.payment)
                 .coverLetter(post.coverLetter)
+                .build();
+    }
+
+    public static Point toSharePoint(int point, PointType pointType, int totalPoint, Member member,
+            CoverLetter coverLetter) {
+
+        return Point.builder()
+                .point(point)
+                .pointType(pointType)
+                .totalPoint(totalPoint)
+                .member(member)
+                .coverLetter(coverLetter)
                 .build();
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/repository/PointRepository.java
@@ -16,6 +16,7 @@ public interface PointRepository extends JpaRepository<Point, Long> {
 
     Page<Point> findByMemberAndPointType(Member member, PointType pointType, Pageable pageable);
 
+    @Query("SELECT p FROM Point p WHERE p.member = :member AND p.pointType <> 'CHARGE'")
     Page<Point> getPointByMember(Member member, Pageable pageable);
 
     Optional<Point> getPointByPayment(Payment payment);

--- a/src/main/java/com/codez4/meetfolio/domain/point/service/PointCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/service/PointCommandService.java
@@ -1,5 +1,11 @@
 package com.codez4.meetfolio.domain.point.service;
 
+import static com.codez4.meetfolio.domain.point.dto.PointRequest.toEntity;
+import static com.codez4.meetfolio.domain.point.dto.PointRequest.toSharePoint;
+import static com.codez4.meetfolio.domain.point.dto.PointResponse.toPointProc;
+
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
+import com.codez4.meetfolio.domain.enums.PointType;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.point.Point;
 import com.codez4.meetfolio.domain.point.dto.PointRequest;
@@ -8,9 +14,6 @@ import com.codez4.meetfolio.domain.point.repository.PointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.codez4.meetfolio.domain.point.dto.PointRequest.toEntity;
-import static com.codez4.meetfolio.domain.point.dto.PointResponse.toPointProc;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +33,24 @@ public class PointCommandService {
     public PointResponse.PointProc usePoint(PointRequest.Post post, Member member) {
         Point point = post(post);
         member.setPoint(post.getTotalPoint());
+
+        if (post.getPointType() == PointType.USE_COVER_LETTER) {
+            shareCoverLetter(post);
+        }
         return toPointProc(point);
+    }
+
+    public void shareCoverLetter(PointRequest.Post post) {
+
+        CoverLetter coverLetter = post.getCoverLetter();
+        Member owner = coverLetter.getMember();
+        PointType pointType = PointType.SHARE_COVER_LETTER;
+        int point = 100;
+        int totalPoint = owner.getPoint() + point;
+
+        Point sharePoint = toSharePoint(point, pointType, totalPoint, owner, coverLetter);
+        save(sharePoint);
+        owner.setPoint(totalPoint);
     }
 
 


### PR DESCRIPTION
## 요약

- 타 사용자 조회 시, 공유한 사용자에게 포인트 전달

## 상세 내용

- Point와 Coverletter 관계를 OneToOne 관계에서 ManyToOne 관계로 변경
> 공유된 자소서를 다른 사용자가 여러 번 조회할 경우와 타 사용자 자소서 조회 시 포인트 생성과 공유 자소서로 얻는 포인트 생성의 경우 발생

- PointType에서 SHARE_COVER_LETTER로 공유한 자소서 포인트 타입 설정

- 마이페이지 포인트 사용내역에서 포인트 충전 내역 보이는 오류 해결

## 질문 및 이외 사항

** 자소서 공유한 사용자에게 포인트 전달 결과 **

![image](https://github.com/Meetfolio-Project-CodeZ-Team/Backend/assets/103489352/dfa45a58-dd13-44f5-9cfd-7042b8227fa5)

![image](https://github.com/Meetfolio-Project-CodeZ-Team/Backend/assets/103489352/eebe78cc-2893-462b-96a5-280f0d557915)

** 마이페이지 - 포인트 사용내역 오류 화면 및 해결 **

<img width="650" alt="image" src="https://github.com/Meetfolio-Project-CodeZ-Team/Backend/assets/103489352/8459ce1f-9007-4ec5-ab8a-bdae4c0bf677">

<img width="500" alt="image" src="https://github.com/Meetfolio-Project-CodeZ-Team/Backend/assets/103489352/c6f5b92e-3e79-41ea-80af-c00d53d3c38e">




## 이슈 번호

- close #165 
