### PR TITLE
Refactor: Coverletter 테이블 속성 추가 및 로직 수정

### DIFF
--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/CoverLetter.java
@@ -30,6 +30,9 @@ public class CoverLetter extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String answer;
 
+    @Column(name = "index_member")
+    private Long index;
+
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private ShareType shareType;

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/controller/CoverLetterController.java
@@ -110,8 +110,7 @@ public class CoverLetterController {
             @RequestParam(value = "page", defaultValue = "0") int page) {
         MemberInfo memberInfo = MemberResponse.toMemberInfo(member);
         Member other = memberQueryService.findByMemberName(memberName);
-        return ApiResponse.onSuccess(toOtherMemberCoverLetterListResult(memberInfo,coverLetterQueryService.getOtherCoverLetters(other, page), other
-        ));
+        return ApiResponse.onSuccess(toOtherMemberCoverLetterListResult(memberInfo, coverLetterQueryService.getOtherCoverLetters(other, page), other));
     }
 
     @Operation(summary = "만족도 저장", description = "쿼리 스트링으로 피드백 ID 또는 분석 ID를, request body로 만족도를 전송합니다.")

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterRequest.java
@@ -50,23 +50,24 @@ public class CoverLetterRequest {
         private String jobKeyword;
     }
 
-    @Schema( description = "만족도 DTO")
+    @Schema(description = "만족도 DTO")
     @Getter
-    public static class SatisfactionRequest{
-        @Schema(description = "만족도, 0부터 5까지의 정수만 입력 가능합니다." )
+    public static class SatisfactionRequest {
+        @Schema(description = "만족도, 0부터 5까지의 정수만 입력 가능합니다.")
         @Max(value = 5)
         @Min(value = 0)
         private int satisfaction;
     }
 
-    public static CoverLetter toEntity(Member member, CoverLetterRequest.Post request) {
+    public static CoverLetter toEntity(Member member, CoverLetterRequest.Post request, Long index) {
 
         return CoverLetter.builder()
-            .question(request.getQuestion())
-            .answer(request.getAnswer())
-            .shareType(ShareType.convert(request.getShareType()))
-            .member(member)
-            .build();
+                .question(request.getQuestion())
+                .answer(request.getAnswer())
+                .shareType(ShareType.convert(request.getShareType()))
+                .member(member)
+                .index(index)
+                .build();
     }
 
     @Getter

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/dto/CoverLetterResponse.java
@@ -133,26 +133,24 @@ public class CoverLetterResponse {
         private AnalysisInfo analysisInfo;
     }
 
-    public static CoverLetterListResult toCoverLetterListResult(MemberInfo memberInfo, Page<CoverLetterItem> coverLetters) {
-        CoverLetterList coverLetterList = toCoverLetterList(coverLetters);
+    public static CoverLetterListResult toCoverLetterListResult(MemberInfo memberInfo, CoverLetterList coverLetters) {
         return CoverLetterListResult.builder()
                 .memberInfo(memberInfo)
-                .coverLetterInfo(coverLetterList)
+                .coverLetterInfo(coverLetters)
                 .build();
     }
 
-    public static OtherMemberCoverLetterListResult toOtherMemberCoverLetterListResult(MemberInfo memberInfo, Page<CoverLetterItem> coverLetters, Member other){
-        CoverLetterList coverLetterList = toCoverLetterList(coverLetters);
+    public static OtherMemberCoverLetterListResult toOtherMemberCoverLetterListResult(MemberInfo memberInfo, CoverLetterList coverLetters, Member other){
         return OtherMemberCoverLetterListResult.builder()
                 .memberInfo(memberInfo)
-                .coverLetterInfo(coverLetterList)
+                .coverLetterInfo(coverLetters)
                 .memberName(other.getEmail().split("@")[0])
                 .profile(other.getProfile().name())
                 .build();
     }
 
-    public static CoverLetterList toCoverLetterList(Page<CoverLetterItem> coverLetters) {
-        List<CoverLetterItem> coverLetterItems = coverLetters.stream().toList();
+    public static CoverLetterList toCoverLetterList(Page<CoverLetter> coverLetters) {
+        List<CoverLetterItem> coverLetterItems = coverLetters.stream().map(CoverLetterResponse::toCoverLetterItem).toList();
         return CoverLetterList.builder()
                 .coverLetterInfo(coverLetterItems)
                 .listSize(coverLetterItems.size())
@@ -199,22 +197,15 @@ public class CoverLetterResponse {
         private LocalDateTime createdAt;
     }
 
-    public static CoverLetterItem toCoverLetterItem(CoverLetter coverLetter, long index) {
+    public static CoverLetterItem toCoverLetterItem(CoverLetter coverLetter) {
         return CoverLetterItem.builder()
                 .coverLetterId(coverLetter.getId())
-                .index(index)
+                .index(coverLetter.getIndex())
                 .question(coverLetter.getQuestion())
                 .answer(coverLetter.getAnswer())
                 .createdAt(coverLetter.getCreatedAt())
                 .build();
 
-    }
-
-    public static Page<CoverLetterItem> toPageCoverLetterItem(Page<CoverLetter> coverLetters) {
-        return coverLetters.map(coverLetter -> {
-            long index = coverLetters.getNumberOfElements() - coverLetters.getContent().indexOf(coverLetter);
-            return toCoverLetterItem(coverLetter, index);
-        });
     }
 
     @Schema(description = "자기소개서 작성 & 수정 & 삭제 응답 DTO")

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/repository/CoverLetterRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
 
@@ -18,4 +19,5 @@ public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> 
 
     @Query("SELECT c FROM CoverLetter c WHERE c.member = :member and c.shareType = 'PUBLIC' and c.status = 'ACTIVE'")
     Page<CoverLetter> findPublicAndActiveCoverLetterByMember(Member member, Pageable pageable);
+    Optional<CoverLetter> findFirstByMemberOrderByIdDesc(Member member);
 }

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterCommandService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -23,8 +25,9 @@ public class CoverLetterCommandService {
     private final FeedbackCommandService feedbackCommandService;
 
     public CoverLetterProc write(Member member, CoverLetterRequest.Post request) {
-
-        CoverLetter coverLetter = save(CoverLetterRequest.toEntity(member, request));
+        Optional<CoverLetter> lastCoverLetter = coverLetterRepository.findFirstByMemberOrderByIdDesc(member);
+        Long index = lastCoverLetter.isEmpty() ? 0L : lastCoverLetter.get().getIndex();
+        CoverLetter coverLetter = save(CoverLetterRequest.toEntity(member, request, index+1));
 
         return CoverLetterResponse.toCoverLetterProc(coverLetter.getId());
 

--- a/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
+++ b/src/main/java/com/codez4/meetfolio/domain/coverLetter/service/CoverLetterQueryService.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.codez4.meetfolio.domain.coverLetter.dto.CoverLetterResponse.toCoverLetterList;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -44,21 +46,21 @@ public class CoverLetterQueryService {
         );
     }
 
-    public Page<CoverLetterResponse.CoverLetterItem> getMyCoverLetters(Member member,
+    public CoverLetterResponse.CoverLetterList getMyCoverLetters(Member member,
         int page) {
         PageRequest pageRequest = PageRequest.of(page, 4, Sort.by("id").descending());
         Page<CoverLetter> coverLetters = coverLetterRepository.findActiveByMember(member,
             pageRequest);
-        return CoverLetterResponse.toPageCoverLetterItem(coverLetters);
+        return toCoverLetterList(coverLetters);
     }
 
-    public Page<CoverLetterResponse.CoverLetterItem> getOtherCoverLetters(Member other,
-        int page) {
+    public CoverLetterResponse.CoverLetterList getOtherCoverLetters(Member other,
+                                                                                     int page) {
         PageRequest pageRequest = PageRequest.of(page, 4, Sort.by("id").descending());
 
         Page<CoverLetter> otherCoverLetters = coverLetterRepository.findPublicAndActiveCoverLetterByMember(
             other,
             pageRequest);
-        return CoverLetterResponse.toPageCoverLetterItem(otherCoverLetters);
+        return toCoverLetterList(otherCoverLetters);
     }
 }

--- a/src/main/java/com/codez4/meetfolio/domain/point/dto/PointResponse.java
+++ b/src/main/java/com/codez4/meetfolio/domain/point/dto/PointResponse.java
@@ -1,5 +1,6 @@
 package com.codez4.meetfolio.domain.point.dto;
 
+import com.codez4.meetfolio.domain.coverLetter.CoverLetter;
 import com.codez4.meetfolio.domain.member.Member;
 import com.codez4.meetfolio.domain.member.dto.MemberResponse;
 import com.codez4.meetfolio.domain.point.Point;
@@ -28,9 +29,53 @@ public class PointResponse {
         @Schema(description = "로그인 사용자 정보")
         private MemberResponse.MemberInfo memberInfo;
 
-        @Schema(description = "결제 내역")
+        @Schema(description = "포인트 내역")
         private PointResponse.PointInfo pointInfo;
 
+    }
+
+    @Schema(description = "포인트 적립 내역 목록 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class EarnedPointResult {
+
+        @Schema(description = "로그인 사용자 정보")
+        private MemberResponse.MemberInfo memberInfo;
+
+        @Schema(description = "적립 내역")
+        private PointResponse.EarnedPointInfo pointInfo;
+
+    }
+
+    @Schema(description = "적립 내역 목록 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class EarnedPointInfo {
+
+        @Schema(description = "내 포인트")
+        private int myPoint;
+
+        @Schema(description = "적립 내역 목록")
+        private List<PointResponse.EarnedPointItem> pointList;
+
+        @Schema(description = "페이징된 리스트의 항목 개수")
+        private Integer listSize;
+
+        @Schema(description = "총 페이징 수 ")
+        private Integer totalPage;
+
+        @Schema(description = "전체 데이터의 개수")
+        private Long totalElements;
+
+        @Schema(description = "첫 페이지의 여부")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지의 여부")
+        private Boolean isLast;
     }
 
     @Schema(description = "결제 내역 목록 DTO")
@@ -62,7 +107,7 @@ public class PointResponse {
         private Boolean isLast;
     }
 
-    @Schema(description = "포인트 내역 목록 DTO")
+    @Schema(description = "포인트 내역 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
@@ -80,6 +125,27 @@ public class PointResponse {
         private String type;
 
         @Schema(description = "사용/충전 후 포인트")
+        private int totalPoint;
+    }
+
+    @Schema(description = "포인트 적립 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class EarnedPointItem {
+
+        @Schema(description = "적립일시")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "적립 포인트")
+        private int point;
+
+        @Schema(description = "자소서 번호")
+        private long coverLetterId;
+
+        @Schema(description = "적립 후 포인트")
         private int totalPoint;
     }
 
@@ -120,9 +186,30 @@ public class PointResponse {
 
     }
 
+    public static EarnedPointResult toEarnedPointResult(Member member, Page<Point> points) {
+        return EarnedPointResult.builder()
+                .memberInfo(toMemberInfo(member))
+                .pointInfo(toEarnedPointInfo(member.getPoint(), points))
+                .build();
+
+    }
+
     public static PointInfo toPointInfo(int myPoint, Page<Point> points) {
         List<PointItem> pointList = points.stream().map(PointResponse::toPointItem).toList();
         return PointInfo.builder()
+                .myPoint(myPoint)
+                .pointList(pointList)
+                .listSize(pointList.size())
+                .totalPage(points.getTotalPages())
+                .totalElements(points.getTotalElements())
+                .isFirst(points.isFirst())
+                .isLast(points.isLast())
+                .build();
+    }
+
+    public static EarnedPointInfo toEarnedPointInfo(int myPoint, Page<Point> points) {
+        List<EarnedPointItem> pointList = points.stream().map(PointResponse::toEarnedPointItem).toList();
+        return EarnedPointInfo.builder()
                 .myPoint(myPoint)
                 .pointList(pointList)
                 .listSize(pointList.size())
@@ -145,6 +232,16 @@ public class PointResponse {
                 .createdAt(point.getCreatedAt())
                 .point(point.getPoint())
                 .type(point.getPointType().getDescription())
+                .totalPoint(point.getTotalPoint())
+                .build();
+    }
+
+    public static EarnedPointItem toEarnedPointItem(Point point) {
+        CoverLetter coverLetter = point.getCoverLetter();
+        return EarnedPointItem.builder()
+                .createdAt(point.getCreatedAt())
+                .point(point.getPoint())
+                .coverLetterId(coverLetter.getIndex())
                 .totalPoint(point.getTotalPoint())
                 .build();
     }


### PR DESCRIPTION
## 요약

- Coverletter 테이블 속성 추가 및 로직 수정

## 상세 내용

- 내 자소서 목록 조회/ 남의 자소서 목록 조회/ 포인트 적립 내역 조회 시 비즈니스 로직에서 사용되는 값인 각 사용자의 자소서 번호를 따로 데이터에 저장하는 것이 효율적이라 생각되어, index_member 속성으로 추가함
- 테이블 구조 변경에 따른 로직 수정

## 질문 및 이외 사항

-

## 이슈 번호

- close #169 
